### PR TITLE
feat: add styled chatbot interface

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2,19 +2,29 @@ const API_URL = 'http://localhost:8000';
 const chatInput = document.getElementById('chatInput');
 const sendBtn = document.getElementById('send');
 const micBtn = document.getElementById('mic');
-const responseDiv = document.getElementById('response');
+const chatWindow = document.getElementById('chatWindow');
 const audioEl = document.getElementById('audio');
+
+function appendMessage(text, sender) {
+  const msg = document.createElement('div');
+  msg.className = `message ${sender}`;
+  msg.textContent = text;
+  chatWindow.appendChild(msg);
+  chatWindow.scrollTop = chatWindow.scrollHeight;
+}
 
 sendBtn.onclick = async () => {
   const text = chatInput.value.trim();
   if (!text) return;
+  appendMessage(text, 'user');
+  chatInput.value = '';
   const res = await fetch(`${API_URL}/chat`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ text })
   });
   const data = await res.json();
-  responseDiv.textContent = data.answer || '';
+  if (data.answer) appendMessage(data.answer, 'bot');
   if (data.audio) {
     audioEl.src = `data:audio/wav;base64,${data.audio}`;
     audioEl.play();
@@ -38,10 +48,8 @@ micBtn.onclick = async () => {
         body: blob
       });
       const data = await res.json();
-      let text = '';
-      if (data.transcript) text += `You: ${data.transcript}\n`;
-      if (data.answer) text += `Bot: ${data.answer}`;
-      responseDiv.textContent = text;
+      if (data.transcript) appendMessage(data.transcript, 'user');
+      if (data.answer) appendMessage(data.answer, 'bot');
       if (data.audio) {
         audioEl.src = `data:audio/wav;base64,${data.audio}`;
         audioEl.play();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,38 +1,21 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Property Chatbot</title>
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <h1>Ask About Properties</h1>
-  <input type="text" id="query" placeholder="Type your question..." />
-  <button onclick="ask()">Ask</button>
-
-  <div id="response" style="margin-top: 20px; font-family: sans-serif;"></div>
-
-  <script>
-    async function ask() {
-      const query = document.getElementById('query').value;
-      const responseDiv = document.getElementById('response');
-      responseDiv.innerHTML = "Loading...";
-
-      try {
-        const res = await fetch('/chat', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify({ text: query })
-        });
-
-        const data = await res.json();
-        console.log("Response JSON:", data);
-        responseDiv.innerHTML = data.answer || "(No response)";
-      } catch (err) {
-        console.error(err);
-        responseDiv.innerHTML = "Something went wrong.";
-      }
-    }
-  </script>
+  <div class="chat-container">
+    <div id="chatWindow" class="chat-window"></div>
+    <div class="input-area">
+      <input type="text" id="chatInput" placeholder="Ask about properties..." />
+      <button id="send">Send</button>
+      <button id="mic">🎙️</button>
+    </div>
+    <audio id="audio" hidden></audio>
+  </div>
+  <script src="app.js"></script>
 </body>
 </html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,76 @@
+body {
+  font-family: 'Segoe UI', Tahoma, sans-serif;
+  background: #f5f5f5;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  margin: 0;
+}
+
+.chat-container {
+  width: 100%;
+  max-width: 600px;
+  background: #fff;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+  box-sizing: border-box;
+  height: 80vh;
+}
+
+.chat-window {
+  flex: 1;
+  overflow-y: auto;
+  margin-bottom: 10px;
+  display: flex;
+  flex-direction: column;
+}
+
+.message {
+  padding: 10px 15px;
+  margin: 5px;
+  border-radius: 15px;
+  max-width: 80%;
+}
+
+.message.user {
+  align-self: flex-end;
+  background: #DCF8C6;
+}
+
+.message.bot {
+  align-self: flex-start;
+  background: #ECECEC;
+}
+
+.input-area {
+  display: flex;
+  gap: 10px;
+}
+
+#chatInput {
+  flex: 1;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+#send, #mic {
+  padding: 0 15px;
+  border: none;
+  border-radius: 4px;
+  background: #007bff;
+  color: white;
+  cursor: pointer;
+}
+
+#send:hover, #mic:hover {
+  background: #0056b3;
+}
+
+#mic {
+  width: 50px;
+}


### PR DESCRIPTION
## Summary
- replace simple page with chat container and input controls
- style interface with new CSS for chat bubbles and layout
- update JS to append user and bot messages and play audio replies

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/real-estate-agent/package.json')*
- `python -m py_compile backend/property_chatbot.py`


------
https://chatgpt.com/codex/tasks/task_e_68937a002db48326b36abfd59bc59873