### PR TITLE
feat: add translucent responsive UI

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,3 +13,8 @@ This directory contains a minimal browser client that interacts with the backend
 3. Open [http://localhost:8001](http://localhost:8001) in a browser. Enter a question or use the microphone button to speak.
 
 The page sends requests to the backend's `/chat` and `/voice` endpoints and plays any audio response returned.
+
+## Mobile-friendly UI
+
+The interface uses a translucent, Apple-inspired design and adapts to both phones and laptops. On small screens the chat
+container expands to fill the viewport, giving a native-app feel.

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -41,14 +41,16 @@ body {
 
 .message.user {
   align-self: flex-end;
-  background: rgba(202, 255, 207, 0.8);
+  background: rgba(202, 255, 207, 0.9);
+  color: #1a1a1a;
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
 }
 
 .message.bot {
   align-self: flex-start;
-  background: rgba(238, 238, 238, 0.8);
+  background: rgba(238, 238, 238, 0.9);
+  color: #1a1a1a;
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
 }

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,24 +1,27 @@
 body {
-  font-family: 'Segoe UI', Tahoma, sans-serif;
-  background: #f5f5f5;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Tahoma, sans-serif;
+  background: linear-gradient(135deg, #dfe9f3 0%, #ffffff 100%);
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 100vh;
+  min-height: 100vh;
   margin: 0;
 }
 
 .chat-container {
   width: 100%;
   max-width: 600px;
-  background: #fff;
-  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.25);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  border-radius: 16px;
   display: flex;
   flex-direction: column;
   padding: 20px;
   box-sizing: border-box;
   height: 80vh;
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  border: 1px solid rgba(255, 255, 255, 0.3);
 }
 
 .chat-window {
@@ -38,12 +41,16 @@ body {
 
 .message.user {
   align-self: flex-end;
-  background: #DCF8C6;
+  background: rgba(202, 255, 207, 0.8);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
 }
 
 .message.bot {
   align-self: flex-start;
-  background: #ECECEC;
+  background: rgba(238, 238, 238, 0.8);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
 }
 
 .input-area {
@@ -73,4 +80,15 @@ body {
 
 #mic {
   width: 50px;
+}
+
+@media (max-width: 600px) {
+  body {
+    align-items: stretch;
+  }
+
+  .chat-container {
+    border-radius: 0;
+    height: 100vh;
+  }
 }


### PR DESCRIPTION
## Summary
- add Apple-style translucent design and glass effect
- make chat interface responsive for phones
- document mobile-friendly UI in frontend readme

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'frontend/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6893c06aab148326aec31d6b7208f350