### PR TITLE
feat: enhance real estate chat UI

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,27 +1,37 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Property Chatbot</title>
-  <link rel="stylesheet" href="styles.css" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
-</head>
-<body>
-  <header class="app-header">
-    <h1>DreamHome Chat</h1>
-  </header>
-  <div class="chat-container">
-    <div id="chatWindow" class="chat-window"></div>
-    <div class="input-area">
-      <input type="text" id="chatInput" placeholder="Ask about properties..." />
-      <button id="send">Send</button>
-      <button id="mic">🎙️</button>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Property Chatbot</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div class="hero">
+      <header class="app-header">
+        <h1>DreamHome Chat</h1>
+        <p class="tagline">Find your perfect place</p>
+      </header>
+      <div class="chat-container">
+        <div id="chatWindow" class="chat-window"></div>
+        <div class="input-area">
+          <input
+            type="text"
+            id="chatInput"
+            placeholder="Ask about properties..."
+          />
+          <button id="send">Send</button>
+          <button id="mic">🎙️</button>
+        </div>
+        <audio id="audio" hidden></audio>
+      </div>
     </div>
-    <audio id="audio" hidden></audio>
-  </div>
-  <script src="app.js"></script>
-</body>
+    <script src="app.js"></script>
+  </body>
 </html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -9,13 +9,25 @@
 }
 
 body {
+  font-family: "Poppins", sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text-color);
+  background: url("https://images.unsplash.com/photo-1501183638710-841dd1904471?auto=format&fit=crop&w=1350&q=80")
+    no-repeat center center/cover fixed;
+}
 
+.hero {
+  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
-
-  min-height: 100vh;
-  margin: 0;
+  padding: 20px;
+  background: rgba(255, 255, 255, 0.4);
+  backdrop-filter: blur(4px);
 }
 
 .app-header {
@@ -24,10 +36,16 @@ body {
   color: var(--brand-primary);
 }
 
+.app-header .tagline {
+  margin-top: -10px;
+  font-weight: 400;
+  color: var(--text-color);
+}
+
 .chat-container {
   width: 100%;
   max-width: 600px;
-
+  background-color: var(--container-bg);
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
   border-radius: 16px;
   display: flex;
@@ -37,7 +55,6 @@ body {
   height: 80vh;
   backdrop-filter: blur(20px) saturate(180%);
   -webkit-backdrop-filter: blur(20px) saturate(180%);
-
 }
 
 .chat-window {
@@ -53,18 +70,20 @@ body {
   margin: 5px;
   border-radius: 15px;
   max-width: 80%;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+  animation: fadeIn 0.3s ease-in;
 }
 
 .message.user {
   align-self: flex-end;
-
+  background: var(--bubble-user-bg);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
 }
 
 .message.bot {
   align-self: flex-start;
-
+  background: var(--bubble-bot-bg);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
 }
@@ -81,7 +100,8 @@ body {
   border-radius: 4px;
 }
 
-#send, #mic {
+#send,
+#mic {
   padding: 0 15px;
   border: none;
   border-radius: 4px;
@@ -89,9 +109,11 @@ body {
   color: white;
   cursor: pointer;
   transition: background 0.2s ease-in-out;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
-#send:hover, #mic:hover {
+#send:hover,
+#mic:hover {
   background: var(--brand-accent);
 }
 
@@ -107,5 +129,16 @@ body {
   .chat-container {
     border-radius: 0;
     height: 100vh;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }


### PR DESCRIPTION
## Summary
- Add hero section with tagline to highlight DreamHome brand and host the chat interface
- Apply property-themed background and improved chat/message styling for a more polished real estate look

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest`
- `npx prettier --check frontend/index.html frontend/styles.css`


------
https://chatgpt.com/codex/tasks/task_e_6893c5d67fd48326831185faf0b2cf60