### PR TITLE
chore: configure frontend API URL

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,8 +1,7 @@
 // Basic frontend logic for the chatbot widget
-// Use the current origin so the frontend works regardless of where the server
-// is hosted. This avoids CORS/port issues when the page is served from the
-// backend itself.
-const API_URL = window.location.origin;
+// Define the backend API URL. This defaults to the local FastAPI server but
+// can be overridden by setting `window.API_URL` before this script loads.
+const API_URL = window.API_URL || 'http://localhost:8000';
 
 const messagesEl = document.getElementById('chatbot-messages');
 const form = document.getElementById('chatbot-form');


### PR DESCRIPTION
## Summary
- point frontend to FastAPI backend by defaulting `API_URL` to `http://localhost:8000`
- allow overriding the backend URL via `window.API_URL`

## Testing
- `node --check frontend/app.js`
- `npm test` *(fails: Could not read package.json)*
- `uvicorn web_app:app --port 8000` *(fails: jinja2 must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_6894cf65f9f48326b66d04a08f81d3f5