### PR TITLE
fix: include inference config for Nova requests

### DIFF
--- a/backend/property_chatbot.py
+++ b/backend/property_chatbot.py
@@ -85,14 +85,23 @@ class LLMClient:
             f"Listings:\n{context}\n\nQuestion: {question}"
         )
 
-        body = json.dumps({
-            "messages": [
-                {
-                    "role": "user",
-                    "content": [{"text": merged_prompt}]
-                }
-            ]
-        })
+        body = json.dumps(
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"text": merged_prompt}],
+                    }
+                ],
+                # Nova models require an explicit inference configuration. Without at
+                # least ``maxTokens`` the Bedrock service responds with a
+                # ``ValidationException`` which surfaces to the frontend as
+                # "Failed to generate an answer." Supplying a conservative
+                # ``maxTokens`` and temperature ensures the request is valid and
+                # prevents the chat from failing for simple greetings like "Hi".
+                "inferenceConfig": {"maxTokens": 256, "temperature": 0.7},
+            }
+        )
 
         try:
             response = self.client.invoke_model(


### PR DESCRIPTION
## Summary
- add required `inferenceConfig` with maxTokens and temperature to Nova model requests to avoid validation errors that caused `Failed to generate an answer`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894d21c8670832695caf1ffed088b79