### PR TITLE
Handle invalid AWS signatures

### DIFF
--- a/backend/web_app.py
+++ b/backend/web_app.py
@@ -68,12 +68,12 @@
 #     uvicorn.run(app, host="0.0.0.0", port=8000)
 
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, UploadFile, File
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from fastapi.middleware.cors import CORSMiddleware
-from property_chatbot import process_user_query
+from property_chatbot import process_user_query, process_user_audio
 
 app = FastAPI()
 
@@ -105,4 +105,19 @@ async def chat(request: Request):
         return {
             "reply": "Sorry, something went wrong. Please try again later.",
             "properties": [],
+        }
+
+
+@app.post("/voice")
+async def voice(file: UploadFile = File(...)):
+    try:
+        audio_bytes = await file.read()
+        return await process_user_audio(audio_bytes)
+    except Exception as exc:
+        print("Voice processing failed:", exc)
+        return {
+            "reply": "Sorry, something went wrong. Please try again later.",
+            "properties": [],
+            "transcript": "",
+            "audio": "",
         }


### PR DESCRIPTION
## Summary
- Catch and report InvalidSignatureException with a clearer message
- Propagate the same friendly error handling to Sonic transcribe and synthesis helpers
- Add Nova Sonic-driven voice endpoint and fetch property listings via RAG only when the query asks for them

## Testing
- `python backend/property_chatbot.py --text hi`
- `python backend/property_chatbot.py --text "house in Seattle"`
- `python -m py_compile backend/property_chatbot.py backend/web_app.py`


------
https://chatgpt.com/codex/tasks/task_e_6894f9f235d48326a01d485996fc183a