### PR TITLE
fix: send correct field name to chat endpoint

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -50,7 +50,7 @@ form.addEventListener('submit', async (e) => {
     const res = await fetch(`${API_URL}/chat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ message: text })
+      body: JSON.stringify({ text })
     });
     if (!res.ok) {
       throw new Error(`Request failed with status ${res.status}`);


### PR DESCRIPTION
## Summary
- ensure chatbot frontend posts `text` to backend `/chat`

## Testing
- `pytest`
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68951b7839ec83268b5b17dbc1972a7a