### PR TITLE
Handle backend agent responses

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -57,11 +57,23 @@ form.addEventListener('submit', async (e) => {
     }
     const data = await res.json();
 
-    if (data.reply) appendMessage(data.reply, 'bot');
-    if (Array.isArray(data.properties)) {
+    if (data.reply) {
+      appendMessage(data.reply, 'bot');
+    } else if (Array.isArray(data.properties)) {
       data.properties.forEach((p) =>
         appendMessage({ type: 'property', ...p }, 'bot')
       );
+    } else if (data.result_type === 'message' && data.content) {
+      appendMessage(data.content, 'bot');
+    } else if (
+      data.result_type === 'property_cards' &&
+      Array.isArray(data.content)
+    ) {
+      data.content.forEach((p) =>
+        appendMessage({ type: 'property', ...p }, 'bot')
+      );
+    } else {
+      appendMessage('Sorry, something went wrong. Please try again later.', 'bot');
     }
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## Summary
- handle backend `result_type` and `content` fields in the chat widget
- fallback to property cards or text replies depending on agent output

## Testing
- `node --check frontend/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68952889449c8326bbf7f215ce4e068c