### PR TITLE
Add general real estate info agent

### DIFF
--- a/backend/agents/__init__.py
+++ b/backend/agents/__init__.py
@@ -1,10 +1,12 @@
 from .base import Agent, AgentRegistry
 from .router import QueryRouterAgent
 from .search import PropertySearchAgent
+from .info import RealEstateInfoAgent
 
 __all__ = [
     "Agent",
     "AgentRegistry",
     "QueryRouterAgent",
     "PropertySearchAgent",
+    "RealEstateInfoAgent",
 ]

--- a/backend/agents/info.py
+++ b/backend/agents/info.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict
+
+from .base import Agent
+from property_chatbot import LLMClient
+
+
+class RealEstateInfoAgent(Agent):
+    """Answer general real-estate questions using an LLM."""
+
+    def __init__(self, registry=None, llm: LLMClient | None = None) -> None:
+        super().__init__("RealEstateInfoAgent", registry)
+        self.llm = llm or LLMClient()
+
+    async def handle(self, query: str, **_: Any) -> Dict[str, Any]:
+        answer = await asyncio.to_thread(self.llm.answer_general, query)
+        return {
+            "result_type": "message",
+            "content": answer,
+            "source_agents": [self.name],
+        }

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -41,8 +41,7 @@ class QueryRouterAgent(Agent):
                 "source_agents": [self.name],
             }
 
-        return {
-            "result_type": "message",
-            "content": "Sorry, I can't handle that request yet.",
-            "source_agents": [self.name],
-        }
+        info_agent = self.registry.get("RealEstateInfoAgent")
+        result = await info_agent.handle(query=query)
+        result["source_agents"].insert(0, self.name)
+        return result

--- a/backend/web_app.py
+++ b/backend/web_app.py
@@ -11,6 +11,7 @@ from fastapi.templating import Jinja2Templates
 from agents.base import AgentRegistry
 from agents.router import QueryRouterAgent
 from agents.search import PropertySearchAgent
+from agents.info import RealEstateInfoAgent
 from property_chatbot import SonicClient
 
 app = FastAPI()
@@ -30,6 +31,8 @@ _registry = AgentRegistry()
 _data_path = Path(__file__).with_name("rag_data.json")
 _search_agent = PropertySearchAgent(_data_path, registry=_registry)
 _registry.register(_search_agent)
+_info_agent = RealEstateInfoAgent(registry=_registry)
+_registry.register(_info_agent)
 _router_agent = QueryRouterAgent(registry=_registry)
 _registry.register(_router_agent)
 _sonic = SonicClient()


### PR DESCRIPTION
## Summary
- add RealEstateInfoAgent for general real estate Q&A
- extend LLM client with answer_general method
- route non-property queries to new agent and register in web app

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68952f5d4ca4832696ae3ac736e25093