### PR TITLE
Add coordinator agent for multi-agent real estate chatbot

### DIFF
--- a/backend/agents/__init__.py
+++ b/backend/agents/__init__.py
@@ -1,12 +1,14 @@
 from .base import Agent, AgentRegistry
-from .router import QueryRouterAgent
+from .coordinator import CoordinatorAgent
 from .search import PropertySearchAgent
 from .info import RealEstateInfoAgent
+from .router import QueryRouterAgent
 
 __all__ = [
     "Agent",
     "AgentRegistry",
-    "QueryRouterAgent",
+    "CoordinatorAgent",
     "PropertySearchAgent",
     "RealEstateInfoAgent",
+    "QueryRouterAgent",
 ]

--- a/backend/agents/coordinator.py
+++ b/backend/agents/coordinator.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Dict, List
+
+from .base import Agent
+
+logger = logging.getLogger(__name__)
+
+
+class CoordinatorAgent(Agent):
+    """Coordinate multiple specialized agents and aggregate their output."""
+
+    def __init__(self, agent_names: List[str], registry=None) -> None:
+        super().__init__("CoordinatorAgent", registry)
+        self.agent_names = agent_names
+
+    async def _run_agent(self, agent: Agent, **kwargs: Any) -> Dict[str, Any]:
+        try:
+            logger.debug("Running agent %s", agent.name)
+            return await agent.handle(**kwargs)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.exception("Agent %s failed", agent.name)
+            return {
+                "result_type": "error",
+                "content": str(exc),
+                "source_agents": [agent.name],
+            }
+
+    async def handle(self, **kwargs: Any) -> Dict[str, Any]:
+        tasks = []
+        for name in self.agent_names:
+            try:
+                agent = self.registry.get(name)
+            except KeyError:
+                logger.error("Agent %s is not registered", name)
+                continue
+            tasks.append(self._run_agent(agent, **kwargs))
+
+        results = await asyncio.gather(*tasks, return_exceptions=False)
+
+        aggregated: Dict[str, Any] = {
+            "result_type": "aggregate",
+            "content": {},
+            "source_agents": [self.name],
+        }
+
+        for res in results:
+            rt = res.get("result_type")
+            content = res.get("content")
+            aggregated["source_agents"].extend(res.get("source_agents", []))
+
+            if rt == "message":
+                aggregated["content"].setdefault("messages", []).append(content)
+            elif rt == "property_cards":
+                aggregated["content"].setdefault("property_cards", []).extend(content)
+            elif rt == "error":
+                aggregated["content"].setdefault("errors", []).append(content)
+            else:
+                aggregated["content"].setdefault(rt or "unknown", []).append(content)
+
+        return aggregated

--- a/backend/agents/info.py
+++ b/backend/agents/info.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any, Dict
 
 from .base import Agent
 from property_chatbot import LLMClient
+
+
+logger = logging.getLogger(__name__)
 
 
 class RealEstateInfoAgent(Agent):
@@ -15,7 +19,16 @@ class RealEstateInfoAgent(Agent):
         self.llm = llm or LLMClient()
 
     async def handle(self, query: str, **_: Any) -> Dict[str, Any]:
-        answer = await asyncio.to_thread(self.llm.answer_general, query)
+        logger.debug("Handling info query: %s", query)
+        try:
+            answer = await asyncio.to_thread(self.llm.answer_general, query)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("RealEstateInfoAgent failed")
+            return {
+                "result_type": "error",
+                "content": str(exc),
+                "source_agents": [self.name],
+            }
         return {
             "result_type": "message",
             "content": answer,

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -72,6 +72,18 @@ form.addEventListener('submit', async (e) => {
       data.content.forEach((p) =>
         appendMessage({ type: 'property', ...p }, 'bot')
       );
+    } else if (
+      data.result_type === 'aggregate' &&
+      data.content
+    ) {
+      if (Array.isArray(data.content.messages)) {
+        data.content.messages.forEach((m) => appendMessage(m, 'bot'));
+      }
+      if (Array.isArray(data.content.property_cards)) {
+        data.content.property_cards.forEach((p) =>
+          appendMessage({ type: 'property', ...p }, 'bot')
+        );
+      }
     } else {
       appendMessage('Sorry, something went wrong. Please try again later.', 'bot');
     }


### PR DESCRIPTION
## Summary
- Implement `CoordinatorAgent` to orchestrate multiple specialized agents and aggregate their responses
- Add logging and basic error handling for info and property search agents
- Register coordinator in the FastAPI app and update frontend to consume aggregated payloads

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689532bad9d88326b2d86cf9efa96ed2