### PR TITLE
Show property cards only for property-related queries

### DIFF
--- a/backend/agents/__init__.py
+++ b/backend/agents/__init__.py
@@ -3,6 +3,7 @@ from .coordinator import CoordinatorAgent
 from .search import PropertySearchAgent
 from .info import RealEstateInfoAgent
 from .router import QueryRouterAgent
+from .intent import IntentClassifierAgent
 
 __all__ = [
     "Agent",
@@ -11,4 +12,5 @@ __all__ = [
     "PropertySearchAgent",
     "RealEstateInfoAgent",
     "QueryRouterAgent",
+    "IntentClassifierAgent",
 ]

--- a/backend/agents/intent.py
+++ b/backend/agents/intent.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, Dict, List
+
+from .base import Agent
+from property_chatbot import PropertyRetriever
+
+
+class IntentClassifierAgent(Agent):
+    """Classify a user's query to decide if property search is needed.
+
+    The agent uses the property retriever to see if any listings match the
+    query once short, non-informative tokens are removed. If no listings are
+    found the intent is considered ``general_info``. Otherwise the intent is
+    ``property_search``.
+    """
+
+    def __init__(self, data_file: Path | str, limit: int = 1, registry=None) -> None:
+        super().__init__("IntentClassifierAgent", registry)
+        self.retriever = PropertyRetriever(data_file)
+        self.limit = limit
+
+    async def handle(self, query: str, **_: Any) -> Dict[str, Any]:
+        # Remove very short tokens so greetings like "hi" don't match
+        tokens = [t.rstrip("s") for t in query.lower().split() if len(t) >= 3]
+        if not tokens:
+            intent = "general_info"
+        else:
+            cleaned = " ".join(tokens)
+            listings: List[Dict[str, Any]] = await asyncio.to_thread(
+                self.retriever.search, cleaned, self.limit
+            )
+            intent = "property_search" if listings else "general_info"
+
+        return {
+            "result_type": "intent",
+            "content": intent,
+            "source_agents": [self.name],
+        }
+


### PR DESCRIPTION
## Summary
- Remove static keyword filtering from PropertySearchAgent
- Add IntentClassifierAgent and update QueryRouterAgent to decide when to run property search

## Testing
- `pytest -q`
- `python - <<'PY'
import asyncio, sys
sys.path.append('backend')
from agents.base import AgentRegistry
from agents.search import PropertySearchAgent
from agents.info import RealEstateInfoAgent
from agents.router import QueryRouterAgent
from agents.intent import IntentClassifierAgent
from pathlib import Path

registry=AgentRegistry()
search_agent=PropertySearchAgent(Path('backend/rag_data.json'), registry=registry)
info_agent=RealEstateInfoAgent(registry=registry)
intent_agent=IntentClassifierAgent(Path('backend/rag_data.json'), registry=registry)
router=QueryRouterAgent(registry=registry)
for a in (search_agent, info_agent, intent_agent, router):
    registry.register(a)

async def run(q):
    res=await router.handle(query=q)
    print(q, res, '\n')

async def main():
    await run("Hi")
    await run("Looking for office space in Los Angeles")
asyncio.run(main())
PY`

------
https://chatgpt.com/codex/tasks/task_e_689600defc4083269b37ab82be8e7065