### PR TITLE
Simplify backend and add LangGraph Bedrock integration

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,48 +1,37 @@
 # Property Listing Chatbot Backend
 
-This directory hosts the FastAPI service and supporting modules for the property listing assistant.
+This directory contains a small FastAPI service that answers real-estate
+questions. The service uses [LangGraph](https://github.com/langchain-ai/langgraph)
+to orchestrate a workflow that searches local property data and calls the
+Amazon Nova model through Bedrock to craft a response.
 
 ## Setup
 
-1. Install dependencies and configure AWS credentials for Bedrock:
-   ```bash
-   python -m pip install -r requirements.txt
-   export AWS_ACCESS_KEY_ID=...
-   export AWS_SECRET_ACCESS_KEY=...
-   export AWS_DEFAULT_REGION=us-east-1
-   ```
-2. (Optional) Start the demo RAG server populated with 100 commercial listings:
-   ```bash
-   uvicorn rag_server:app --reload --port 8001
-   ```
-   Then point the chatbot at it:
-   ```bash
-   export RAG_SERVER_URL=http://localhost:8001/query
-   ```
-   The server indexes `rag_data.json`, which contains 100 richly described properties for demo queries.
-
-## Command line
-
-Run the orchestrator directly:
 ```bash
-python property_chatbot.py --text "3 bedroom house in Seattle"
-python property_chatbot.py --audio question.wav
+python -m pip install -r requirements.txt
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_DEFAULT_REGION=us-east-1
 ```
-The audio command prints the transcript and answer and writes `response_audio.pcm`.
+
+The application loads sample listings from `rag_data.json` bundled in this
+directory. Customize the file or connect a retrieval service for your own data.
 
 ## REST API
 
-Start the FastAPI server:
+Start the server:
+
 ```bash
-uvicorn web_app:app --reload
+uvicorn langgraph_app:app --reload
 ```
 
-Send sample requests:
+Send a request:
+
 ```bash
 curl -X POST http://localhost:8000/chat \
   -H "Content-Type: application/json" \
-  -d '{"text": "3 bedroom house in Seattle"}'
-
-curl -X POST http://localhost:8000/voice -F "file=@question.wav"
+  -d '{"message": "3 bedroom house in Seattle"}'
 ```
-The `/voice` endpoint returns a transcript, text answer, and base64 encoded audio response.
+
+The response contains a text reply and any matching property cards.
+

--- a/backend/langgraph_app.py
+++ b/backend/langgraph_app.py
@@ -1,213 +1,169 @@
 from __future__ import annotations
 
-"""LangGraph-powered multi-agent FastAPI app for real estate queries.
+"""FastAPI service using LangGraph and Amazon Nova via Bedrock."""
 
-This module demonstrates how multiple specialized agents can be orchestrated
-using LangGraph in a directed graph.  Each agent is represented as an async
-function that returns a partial update to a shared state dictionary.  The
-``/chat`` endpoint exposes the graph to external callers and returns a
-standardized JSON payload with the combined results.
-"""
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, TypedDict
 
-from typing import Any, Dict, List, Optional, TypedDict
-
+import boto3
+from botocore.exceptions import ClientError, NoCredentialsError
+from dotenv import load_dotenv
 from fastapi import FastAPI
-from pydantic import BaseModel
 from langgraph.graph import StateGraph, END
+from pydantic import BaseModel
+
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def normalize_listing(p: Dict[str, Any]) -> Dict[str, Any]:
+    """Ensure common fields exist in property dictionaries."""
+
+    return {
+        **p,
+        "address": p.get("address") or p.get("location", "Unknown location"),
+        "bedrooms": p.get("bedrooms") or p.get("sqft") or "N/A",
+    }
+
+
+class PropertyRetriever:
+    """Naive keyword search over local property data."""
+
+    def __init__(self, data_file: Path | str):
+        path = Path(data_file).resolve()
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                self.properties: List[Dict[str, Any]] = json.load(f)
+        except FileNotFoundError:
+            self.properties = []
+
+    def search(self, query: str, limit: int = 3) -> List[Dict[str, Any]]:
+        q_words = query.lower().split()
+        results: List[Dict[str, Any]] = []
+        for p in self.properties:
+            text = (
+                f"{p.get('address', '')} {p.get('description', '')} "
+                f"{p.get('type', '')}"
+            ).lower()
+            if all(word in text for word in q_words):
+                results.append(p)
+            if len(results) >= limit:
+                break
+        return results
+
+
+class LLMClient:
+    """Small wrapper around an Amazon Nova model."""
+
+    def __init__(self, model_id: str = "amazon.nova-lite-v1:0", region: str = "us-east-1"):
+        self.client = boto3.client("bedrock-runtime", region_name=region)
+        self.model_id = model_id
+
+    def answer(self, question: str, listings: List[Dict[str, Any]]) -> str:
+        context_lines: List[str] = []
+        for p in listings:
+            location = p.get("address") or p.get("location", "Unknown location")
+            bedrooms = p.get("bedrooms") or p.get("sqft") or "N/A"
+            price = p.get("price", "N/A")
+            description = p.get("description", "")
+            context_lines.append(
+                f"- {location} {price} {bedrooms} bedrooms. {description}"
+            )
+        context = "\n".join(context_lines) or "No listings matched."
+
+        prompt = (
+            "You are a helpful real-estate assistant. Answer the question using only "
+            "the provided listings.\n\n"
+            f"Listings:\n{context}\n\nQuestion: {question}"
+        )
+
+        body = json.dumps(
+            {
+                "messages": [{"role": "user", "content": [{"text": prompt}]}],
+                "inferenceConfig": {"maxTokens": 256, "temperature": 0.7},
+            }
+        )
+
+        try:
+            resp = self.client.invoke_model(
+                modelId=self.model_id,
+                body=body,
+                contentType="application/json",
+                accept="application/json",
+            )
+            data = json.loads(resp["body"].read())
+            return data["output"]["message"]["content"][0]["text"]
+        except (KeyError, IndexError, TypeError):
+            return "No answer found."
+        except NoCredentialsError:
+            return "Missing AWS credentials for Bedrock."
+        except ClientError as exc:
+            print("LLM invocation failed:", exc)
+            return "Failed to generate an answer."
 
 
 class GraphState(TypedDict, total=False):
-    """State object passed between agents in the LangGraph workflow."""
-
     user_input: str
-    intent: str
     listings: List[Dict[str, Any]]
-    public_records: Dict[str, Any]
-    knowledge: Dict[str, Any]
-    om_pdf_url: str
-    schedule: Dict[str, Any]
-    result_type: str
-    content: Dict[str, Any]
-    source_agents: List[str]
+    answer: str
 
 
-# ---------------------------------------------------------------------------
-# Agent implementations
-# ---------------------------------------------------------------------------
+retriever = PropertyRetriever(Path(__file__).with_name("rag_data.json"))
+llm_client = LLMClient()
 
 
-async def query_router_agent(state: GraphState) -> GraphState:
-    """Rudimentary intent classifier to route user queries.
-
-    The router looks for simple keywords in the user input to determine the
-    next step in the workflow.
-    """
-
-    text = state["user_input"].lower()
-    if "schedule" in text:
-        intent = "schedule"
-    elif "om" in text or "memorandum" in text:
-        intent = "generate_om"
-    else:
-        intent = "search"
-    return {
-        "intent": intent,
-        "source_agents": state.get("source_agents", []) + ["query_router"],
-    }
+async def retrieve_agent(state: GraphState) -> GraphState:
+    logger.info("retrieve_agent input: %s", state.get("user_input"))
+    listings = retriever.search(state["user_input"])
+    logger.info("retrieve_agent found %d listings", len(listings))
+    return {"listings": [normalize_listing(p) for p in listings]}
 
 
-async def property_search_agent(state: GraphState) -> GraphState:
-    """Fetch property listings from commercial real-estate websites.
+async def llm_agent(state: GraphState) -> GraphState:
+    logger.info(
+        "llm_agent answering with %d listings", len(state.get("listings", []))
+    )
+    answer = llm_client.answer(state["user_input"], state.get("listings", []))
+    logger.info("llm_agent output: %s", answer)
+    return {"answer": answer}
 
-    This is a placeholder implementation that returns a mock listing. In a
-    production system this function would scrape LoopNet/Crexi/Brevitas or use
-    their APIs.
-    """
 
-    listings = [
+async def format_agent(state: GraphState) -> GraphState:
+    logger.info(
+        "format_agent formatting %d listings", len(state.get("listings", []))
+    )
+    cards = [
         {
-            "id": "123",
-            "address": "123 Main St, Miami, FL",
-            "price": "$1,000,000",
+            "address": p.get("address"),
+            "price": (
+                f"${p.get('price'):,}"
+                if isinstance(p.get("price"), (int, float))
+                else p.get("price", "N/A")
+            ),
+            "description": p.get("description", ""),
         }
+        for p in state.get("listings", [])
     ]
-    return {
-        "listings": listings,
-        "source_agents": state.get("source_agents", []) + ["property_search"],
-    }
+    logger.info("format_agent returning %d cards", len(cards))
+    return {"reply": state.get("answer", ""), "properties": cards}
 
-
-async def public_record_agent(state: GraphState) -> GraphState:
-    """Fetch public record information from miamidade.gov.
-
-    The current implementation returns mocked data. Replace with real HTTP
-    requests as needed.
-    """
-
-    records = {"123": {"owner": "John Doe", "taxes": "$10,000"}}
-    return {
-        "public_records": records,
-        "source_agents": state.get("source_agents", []) + ["public_record"],
-    }
-
-
-async def knowledge_agent(state: GraphState) -> GraphState:
-    """Embed and retrieve property information using ChromaDB.
-
-    For demonstration purposes the agent only echoes back the listings. The
-    ChromaDB integration would normally store and query embeddings here.
-    """
-
-    knowledge = {"retrieved": state.get("listings", [])}
-    return {
-        "knowledge": knowledge,
-        "source_agents": state.get("source_agents", []) + ["knowledge"],
-    }
-
-
-async def om_generator_agent(state: GraphState) -> GraphState:
-    """Generate an Offering Memorandum PDF based on search results.
-
-    The real implementation would fill a PDF template with property details.
-    Here we simply return a dummy URL.
-    """
-
-    pdf_url = "https://example.com/files/om_dummy.pdf"
-    return {
-        "om_pdf_url": pdf_url,
-        "source_agents": state.get("source_agents", []) + ["om_generator"],
-    }
-
-
-async def scheduler_agent(state: GraphState) -> GraphState:
-    """Book a property tour using the Google Calendar API.
-
-    Only a mock event is created here to illustrate the flow.
-    """
-
-    event = {"id": "evt_123", "status": "confirmed"}
-    return {
-        "schedule": event,
-        "source_agents": state.get("source_agents", []) + ["scheduler"],
-    }
-
-
-async def supervisor_agent(state: GraphState) -> GraphState:
-    """Validate, merge, and finalize the response from prior agents."""
-
-    content: Dict[str, Any] = {}
-    result_parts: List[str] = []
-
-    if state.get("listings"):
-        content["cards"] = state["listings"]
-        result_parts.append("property_cards")
-    if state.get("om_pdf_url"):
-        content["om_pdf_url"] = state["om_pdf_url"]
-        result_parts.append("om_pdf")
-    if state.get("schedule"):
-        content["schedule"] = state["schedule"]
-        result_parts.append("schedule")
-
-    result_type = " + ".join(result_parts) if result_parts else "summary"
-
-    return {
-        "result_type": result_type,
-        "content": content,
-        "source_agents": state.get("source_agents", []) + ["supervisor"],
-    }
-
-
-# ---------------------------------------------------------------------------
-# LangGraph workflow setup
-# ---------------------------------------------------------------------------
 
 workflow = StateGraph(GraphState)
+workflow.add_node("retrieve", retrieve_agent)
+workflow.add_node("llm", llm_agent)
+workflow.add_node("format", format_agent)
 
-workflow.add_node("query_router", query_router_agent)
-workflow.add_node("property_search", property_search_agent)
-workflow.add_node("public_record", public_record_agent)
-workflow.add_node("knowledge", knowledge_agent)
-workflow.add_node("om_generator", om_generator_agent)
-workflow.add_node("scheduler", scheduler_agent)
-workflow.add_node("supervisor", supervisor_agent)
-
-workflow.set_entry_point("query_router")
-
-# Routing after the query router
-workflow.add_conditional_edges(
-    "query_router",
-    lambda s: s.get("intent"),
-    {
-        "search": "property_search",
-        "generate_om": "property_search",  # search first then OM generation
-        "schedule": "scheduler",
-    },
-)
-
-# Common path for search/generate_om intents
-workflow.add_edge("property_search", "public_record")
-workflow.add_edge("public_record", "knowledge")
-
-# After knowledge enrichment, decide whether to generate OM or finish
-workflow.add_conditional_edges(
-    "knowledge",
-    lambda s: s.get("intent"),
-    {
-        "generate_om": "om_generator",
-        "search": "supervisor",
-    },
-)
-
-workflow.add_edge("om_generator", "supervisor")
-workflow.add_edge("scheduler", "supervisor")
-workflow.add_edge("supervisor", END)
+workflow.set_entry_point("retrieve")
+workflow.add_edge("retrieve", "llm")
+workflow.add_edge("llm", "format")
+workflow.add_edge("format", END)
 
 app_graph = workflow.compile()
 
-
-# ---------------------------------------------------------------------------
-# FastAPI application
-# ---------------------------------------------------------------------------
 
 app = FastAPI()
 
@@ -218,20 +174,9 @@ class ChatRequest(BaseModel):
 
 @app.post("/chat")
 async def chat(req: ChatRequest) -> Dict[str, Any]:
-    """Entry point for user interactions.
-
-    The message is passed through the LangGraph workflow and the final state
-    produced by the supervisor agent is returned to the caller.
-    """
-
-    initial_state: GraphState = {
-        "user_input": req.message,
-        "source_agents": [],
-    }
+    logger.info("/chat request: %s", req.message)
+    initial_state: GraphState = {"user_input": req.message}
     result = await app_graph.ainvoke(initial_state)
-    # ``result`` is the final state. Only expose the standardized fields.
-    return {
-        "result_type": result.get("result_type", "summary"),
-        "content": result.get("content", {}),
-        "source_agents": result.get("source_agents", []),
-    }
+    logger.info("/chat response: %s", result)
+    return result
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,10 +1,5 @@
 boto3>=1.34.0
 fastapi
 uvicorn
-requests
-scikit-learn
 python-dotenv
-
 langgraph
-langchain
-chromadb

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -50,7 +50,7 @@ form.addEventListener('submit', async (e) => {
     const res = await fetch(`${API_URL}/chat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text })
+      body: JSON.stringify({ message: text })
     });
     if (!res.ok) {
       throw new Error(`Request failed with status ${res.status}`);


### PR DESCRIPTION
## Summary
- replace complex multi-agent demo with lean LangGraph workflow that queries Amazon Nova via Bedrock
- strip unused dependencies and docs, keeping only essentials
- document and expose new FastAPI endpoint powered by LangGraph
- add logging through the LangGraph agents and endpoint, and align the frontend request payload

## Testing
- `python -m py_compile backend/langgraph_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68960ccc1db48326ae129326c4d8ff6a