### PR TITLE
Add debug prints for triggered agents

### DIFF
--- a/backend/agents/coordinator.py
+++ b/backend/agents/coordinator.py
@@ -19,6 +19,7 @@ class CoordinatorAgent(Agent):
     async def _run_agent(self, agent: Agent, **kwargs: Any) -> Dict[str, Any]:
         try:
             logger.debug("Running agent %s", agent.name)
+            print(f"CoordinatorAgent triggering {agent.name}")
             return await agent.handle(**kwargs)
         except Exception as exc:  # pragma: no cover - defensive logging
             logger.exception("Agent %s failed", agent.name)

--- a/backend/agents/info.py
+++ b/backend/agents/info.py
@@ -20,6 +20,7 @@ class RealEstateInfoAgent(Agent):
 
     async def handle(self, query: str, **_: Any) -> Dict[str, Any]:
         logger.debug("Handling info query: %s", query)
+        print(f"RealEstateInfoAgent triggered with query: {query}")
         try:
             answer = await asyncio.to_thread(self.llm.answer_general, query)
         except Exception as exc:  # pragma: no cover - defensive

--- a/backend/agents/intent.py
+++ b/backend/agents/intent.py
@@ -23,6 +23,7 @@ class IntentClassifierAgent(Agent):
         self.limit = limit
 
     async def handle(self, query: str, **_: Any) -> Dict[str, Any]:
+        print(f"IntentClassifierAgent triggered with query: {query}")
         # Remove very short tokens so greetings like "hi" don't match
         tokens = [t.rstrip("s") for t in query.lower().split() if len(t) >= 3]
         if not tokens:

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -12,14 +12,17 @@ class QueryRouterAgent(Agent):
         super().__init__("QueryRouterAgent", registry)
 
     async def handle(self, query: str, **_: Any) -> Dict[str, Any]:
+        print(f"QueryRouterAgent triggered with query: {query}")
         classifier = self.registry.get("IntentClassifierAgent")
         intent_res = await classifier.handle(query=query)
         intent = intent_res.get("content")
 
         if intent == "property_search":
+            print("QueryRouterAgent dispatching to PropertySearchAgent")
             search_agent = self.registry.get("PropertySearchAgent")
             result = await search_agent.handle(query=query)
         else:
+            print("QueryRouterAgent dispatching to RealEstateInfoAgent")
             info_agent = self.registry.get("RealEstateInfoAgent")
             result = await info_agent.handle(query=query)
 

--- a/backend/agents/search.py
+++ b/backend/agents/search.py
@@ -22,6 +22,7 @@ class PropertySearchAgent(Agent):
 
     async def handle(self, query: str, **_: Any) -> Dict[str, Any]:
         logger.debug("Searching properties for query: %s", query)
+        print(f"PropertySearchAgent triggered with query: {query}")
         try:
             listings: List[Dict[str, Any]] = await asyncio.to_thread(
                 self.retriever.search, query, self.limit


### PR DESCRIPTION
## Summary
- add print statements so each agent logs when it is triggered
- coordinator prints which agent it dispatches
- router prints target agent for each query

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896106418f4832690d548c5864c9e93