### PR TITLE
fix: send text field to chat endpoint

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -50,7 +50,11 @@ form.addEventListener('submit', async (e) => {
     const res = await fetch(`${API_URL}/chat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ message: text })
+      // The backend `/chat` endpoint expects a JSON payload with a
+      // `text` field. Previously we sent `{ message: text }` which
+      // resulted in a 400 "text is required" error. Send the correct
+      // field so the server can process the request.
+      body: JSON.stringify({ text })
     });
     if (!res.ok) {
       throw new Error(`Request failed with status ${res.status}`);


### PR DESCRIPTION
## Summary
- send `text` field from frontend to match backend `/chat`
- avoid 400 `text is required` errors

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68961654c3708326a5f0c0c9cf628963