### PR TITLE
Make chatbot UI translucent

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -28,15 +28,17 @@ function appendMessage(message, sender) {
 
   if (typeof message === 'string') {
     const bubble = document.createElement('div');
-    bubble.className = `px-4 py-2 rounded-lg max-w-[75%] text-sm whitespace-pre-wrap ${
-      sender === 'user' ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-800'
+    bubble.className = `px-4 py-2 rounded-lg max-w-[75%] text-sm whitespace-pre-wrap backdrop-blur-sm ${
+      sender === 'user'
+        ? 'bg-blue-600/80 text-white'
+        : 'bg-gray-200/80 text-gray-800'
     }`;
     bubble.innerHTML = marked.parse(message);
     wrapper.appendChild(bubble);
   } else if (message.type === 'property') {
     const card = document.createElement('div');
     card.className =
-      'w-64 bg-white rounded-lg border shadow-sm overflow-hidden text-left';
+      'w-64 bg-white/80 backdrop-blur-sm rounded-lg border shadow-sm overflow-hidden text-left';
     card.innerHTML = `
       <img src="${message.image}" alt="${message.address}" class="h-36 w-full object-cover" />
       <div class="p-3">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,10 +34,10 @@
     <!-- Chat widget floating bottom-right -->
     <div
       id="chatbot"
-      class="fixed bottom-24 right-4 w-full sm:w-96 max-w-md h-[32rem] bg-white/70 backdrop-blur-sm rounded-lg shadow-lg flex flex-col overflow-hidden"
+      class="fixed bottom-24 right-4 w-full sm:w-96 max-w-md h-[32rem] bg-white/30 backdrop-blur-md rounded-lg shadow-lg flex flex-col overflow-hidden"
     >
       <!-- Header -->
-      <div class="flex items-center bg-blue-600 text-white px-4 py-3 space-x-2">
+      <div class="flex items-center bg-blue-600/80 backdrop-blur-sm text-white px-4 py-3 space-x-2">
         <img
           src="https://dummyimage.com/32x32/ffffff/1e3a8a&text=D"
           alt="Logo"
@@ -47,15 +47,15 @@
       </div>
 
       <!-- Messages -->
-      <div id="chatbot-messages" class="flex-1 overflow-y-auto p-4 space-y-4 bg-gray-50"></div>
+      <div id="chatbot-messages" class="flex-1 overflow-y-auto p-4 space-y-4 bg-white/10 backdrop-blur-sm"></div>
 
       <!-- Input area -->
-      <form id="chatbot-form" class="flex items-center border-t p-3 space-x-2">
+      <form id="chatbot-form" class="flex items-center bg-white/10 backdrop-blur-sm border-t border-white/20 p-3 space-x-2">
         <input
           id="chatbot-input"
           type="text"
           placeholder="Ask about a property..."
-          class="flex-1 border rounded-full px-4 py-2 text-sm focus:outline-none"
+          class="flex-1 border border-white/30 bg-white/60 rounded-full px-4 py-2 text-sm focus:outline-none"
         />
         <button type="submit" class="text-blue-600 p-2" aria-label="Send message">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">


### PR DESCRIPTION
## Summary
- soften chatbot container with translucent white background and blur
- render chat messages and cards with semi-transparent bubbles
- translucent header, message area and input styling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689628889038832688c640578d976971