### PR TITLE
feat: add glass themed frontend scaffold

### DIFF
--- a/frontend/components/assistant-drawer.js
+++ b/frontend/components/assistant-drawer.js
@@ -1,0 +1,15 @@
+let drawer;
+export function initAssistantDrawer() {
+  drawer = document.getElementById('assistant');
+  drawer.innerHTML = `
+    <h3>Assistant</h3>
+    <p id="assistant-content">Context-aware tips appear here.</p>
+    <div class="actions">
+      <button>Refresh</button>
+      <button>Suggest</button>
+    </div>
+  `;
+}
+export function toggleAssistant() {
+  drawer.classList.toggle('hidden');
+}

--- a/frontend/components/command-palette.js
+++ b/frontend/components/command-palette.js
@@ -1,0 +1,44 @@
+let palette,input,listEl,items=[],filtered=[],current=0;
+
+export function initCommandPalette(data) {
+  palette = document.getElementById('command-palette');
+  palette.innerHTML = `<div class="cp-box"><input id="cp-input" placeholder="Type a command"/><div class="cp-list"></div></div>`;
+  input = palette.querySelector('#cp-input');
+  listEl = palette.querySelector('.cp-list');
+  items = [
+    {label:'Go to Sourcing', action:()=>location.hash='#/sourcing'},
+    {label:'Go to Leads', action:()=>location.hash='#/leads'},
+    {label:'Go to Outreach', action:()=>location.hash='#/outreach'},
+  ];
+  (data.savedSearches||[]).forEach(s=>items.push({label:`Search: ${s}`, action:()=>alert('Load '+s)}));
+  filtered = items;
+  render();
+  input.addEventListener('input',()=>{filter();});
+  input.addEventListener('keydown',e=>{
+    if(e.key==='ArrowDown'){current=Math.min(current+1,filtered.length-1);render();}
+    else if(e.key==='ArrowUp'){current=Math.max(current-1,0);render();}
+    else if(e.key==='Enter'){execute();}
+    else if(e.key==='Escape'){togglePalette();}
+  });
+}
+
+function render(){
+  listEl.innerHTML = filtered.map((it,i)=>`<div class="cp-item${i===current?' active':''}" data-idx="${i}">${it.label}</div>`).join('');
+  listEl.querySelectorAll('.cp-item').forEach(el=>el.addEventListener('click',()=>{current=Number(el.dataset.idx);execute();}));
+}
+
+function filter(){
+  const q=input.value.toLowerCase();
+  filtered = items.filter(it=>it.label.toLowerCase().includes(q));
+  current=0;render();
+}
+
+export function togglePalette(){
+  palette.classList.toggle('hidden');
+  if(!palette.classList.contains('hidden')){input.value='';filter();setTimeout(()=>input.focus(),0);} 
+}
+
+function execute(){
+  const cmd = filtered[current];
+  if(cmd){togglePalette();cmd.action();}
+}

--- a/frontend/components/datagrid.js
+++ b/frontend/components/datagrid.js
@@ -1,0 +1,16 @@
+import { skeletonRow } from './skeleton.js';
+
+export function createDataGrid(props=[]) {
+  const el = document.createElement('div');
+  el.id='grid';
+  const sk = document.createElement('div');
+  for(let i=0;i<5;i++) sk.appendChild(skeletonRow());
+  el.appendChild(sk);
+  setTimeout(()=>render(),800);
+  function render(){
+    el.innerHTML = `<table class="data"><thead><tr><th>Address</th><th>Price</th></tr></thead><tbody>`+
+      props.map(p=>`<tr><td>${p.address}</td><td>${p.price}</td></tr>`).join('')+
+      `</tbody></table>`;
+  }
+  return el;
+}

--- a/frontend/components/kanban.js
+++ b/frontend/components/kanban.js
@@ -1,0 +1,42 @@
+import { skeletonCard } from './skeleton.js';
+import { showToast } from './toast.js';
+
+const stages=['New','Contacted','Qualified','Proposal','Closed'];
+
+export function createKanban(leads=[]) {
+  const board=document.createElement('div');
+  board.className='kanban';
+  const columns={};
+  stages.forEach(s=>{
+    const col=document.createElement('div');
+    col.className='kanban-column';
+    col.dataset.stage=s;
+    col.innerHTML=`<h3>${s}</h3>`;
+    const sk=document.createElement('div');for(let i=0;i<3;i++) sk.appendChild(skeletonCard());
+    col.appendChild(sk);
+    col.addEventListener('dragover',e=>e.preventDefault());
+    col.addEventListener('drop',e=>{
+      const id=e.dataTransfer.getData('id');
+      const card=document.getElementById(id);
+      col.appendChild(card);
+      showToast(`Moved ${card.dataset.name} to ${s}`);
+    });
+    board.appendChild(col);
+    columns[s]=col;
+  });
+  setTimeout(()=>render(),800);
+  function render(){
+    stages.forEach(s=>{columns[s].innerHTML=`<h3>${s}</h3>`});
+    leads.forEach(l=>{
+      const card=document.createElement('div');
+      card.className='lead-card';
+      card.draggable=true;
+      card.id='lead-'+l.id;
+      card.dataset.name=l.name;
+      card.innerText=l.name;
+      card.addEventListener('dragstart',e=>e.dataTransfer.setData('id',card.id));
+      columns[l.stage].appendChild(card);
+    });
+  }
+  return board;
+}

--- a/frontend/components/left-rail.js
+++ b/frontend/components/left-rail.js
@@ -1,0 +1,15 @@
+export function initLeftRail(data) {
+  const rail = document.getElementById('left-rail');
+  const list = data.savedSearches || [];
+  rail.innerHTML = `
+    <button id="collapse-rail">≡</button>
+    <div class="filters">
+      <div class="chip">For Sale</div>
+      <div class="chip">Price &lt; 1M</div>
+    </div>
+    <div class="saved">
+      <h4>Saved Searches</h4>
+      <ul>${list.map(s=>`<li class="saved-item">${s}</li>`).join('')}</ul>
+    </div>`;
+  document.getElementById('collapse-rail').addEventListener('click',()=>rail.classList.toggle('collapsed'));
+}

--- a/frontend/components/skeleton.js
+++ b/frontend/components/skeleton.js
@@ -1,0 +1,10 @@
+export function skeletonRow(){
+  const d=document.createElement('div');
+  d.className='skeleton row';
+  return d;
+}
+export function skeletonCard(){
+  const d=document.createElement('div');
+  d.className='skeleton card';
+  return d;
+}

--- a/frontend/components/toast.js
+++ b/frontend/components/toast.js
@@ -1,0 +1,12 @@
+let container;
+export function initToast(){
+  container=document.getElementById('toast-container');
+}
+export function showToast(msg){
+  if(!container) return;
+  const t=document.createElement('div');
+  t.className='toast';
+  t.textContent=msg;
+  container.appendChild(t);
+  setTimeout(()=>t.remove(),3000);
+}

--- a/frontend/components/topbar.js
+++ b/frontend/components/topbar.js
@@ -1,0 +1,22 @@
+export function initTopbar() {
+  const bar = document.getElementById('topbar');
+  bar.innerHTML = `
+    <div class="logo">EstateAI</div>
+    <div class="tabs">
+      <span class="tab" data-route="#/sourcing">Sourcing</span>
+      <span class="tab" data-route="#/leads">Leads</span>
+      <span class="tab" data-route="#/outreach">Outreach</span>
+    </div>
+    <div class="right">
+      <input id="global-search" placeholder="Search" />
+      <div class="avatar">⚫</div>
+    </div>
+  `;
+  bar.querySelectorAll('.tab').forEach(t=>t.addEventListener('click',()=>location.hash=t.dataset.route));
+  return { setActive: (route)=> {
+    bar.querySelectorAll('.tab').forEach(t=>{
+      if(t.dataset.route===route) t.classList.add('active');
+      else t.classList.remove('active');
+    });
+  }};
+}

--- a/frontend/data/sample.json
+++ b/frontend/data/sample.json
@@ -1,0 +1,20 @@
+{
+  "properties": [
+    {"id":1,"address":"123 Main St","price":"$500k"},
+    {"id":2,"address":"456 Oak Ave","price":"$750k"},
+    {"id":3,"address":"789 Pine Dr","price":"$1.2M"}
+  ],
+  "leads": [
+    {"id":1,"name":"Alice","stage":"New"},
+    {"id":2,"name":"Bob","stage":"Contacted"},
+    {"id":3,"name":"Carol","stage":"Qualified"}
+  ],
+  "templates": [
+    {"id":1,"title":"Welcome","body":"Hello {{name}}, thanks for your interest."}
+  ],
+  "cohorts": [
+    {"id":1,"name":"Investors"},
+    {"id":2,"name":"First-time Buyers"}
+  ],
+  "savedSearches": ["Austin Deals","Bay Area Luxury"]
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,70 +1,23 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Real Estate Chatbot</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="styles.css" />
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-  </head>
-  <body class="font-['Poppins'] min-h-screen">
-    <header
-      class="absolute top-0 left-0 right-0 p-4 flex justify-between items-center text-white"
-    >
-      <div class="text-2xl font-bold">DreamHome</div>
-      <nav class="space-x-4 hidden sm:block">
-        <a href="#" class="hover:text-blue-200">Listings</a>
-        <a href="#" class="hover:text-blue-200">Agents</a>
-        <a href="#" class="hover:text-blue-200">Contact</a>
-      </nav>
-    </header>
-    <main class="p-6 text-center text-white drop-shadow-lg mt-20">
-      <h1 class="text-4xl sm:text-5xl font-bold mb-4">
-        Find Your <span class="text-blue-200">Perfect</span> Home
-      </h1>
-      <p class="max-w-xl mx-auto">
-        Browse properties or chat with our assistant for personalized help.
-      </p>
-    </main>
-
-    <!-- Chat widget floating bottom-right -->
-    <div
-      id="chatbot"
-      class="fixed bottom-24 right-4 w-full sm:w-96 max-w-md h-[32rem] bg-white/30 backdrop-blur-md rounded-lg shadow-lg flex flex-col overflow-hidden"
-    >
-      <!-- Header -->
-      <div class="flex items-center bg-blue-600/80 backdrop-blur-sm text-white px-4 py-3 space-x-2">
-        <img
-          src="https://dummyimage.com/32x32/ffffff/1e3a8a&text=D"
-          alt="Logo"
-          class="h-8 w-8 rounded"
-        />
-        <span class="font-semibold">Real Estate Chatbot</span>
-      </div>
-
-      <!-- Messages -->
-      <div id="chatbot-messages" class="flex-1 overflow-y-auto p-4 space-y-4 bg-white/10 backdrop-blur-sm"></div>
-
-      <!-- Input area -->
-      <form id="chatbot-form" class="flex items-center bg-white/10 backdrop-blur-sm border-t border-white/20 p-3 space-x-2">
-        <input
-          id="chatbot-input"
-          type="text"
-          placeholder="Ask about a property..."
-          class="flex-1 border border-white/30 bg-white/60 rounded-full px-4 py-2 text-sm focus:outline-none"
-        />
-        <button type="submit" class="text-blue-600 p-2" aria-label="Send message">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-            <path d="M10.894 2.553a1 1 0 00-1.788 0l-7 14A1 1 0 003 18h14a1 1 0 00.894-1.447l-7-14z" />
-          </svg>
-        </button>
-      </form>
-    </div>
-
-    <script src="app.js"></script>
-  </body>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Real Estate AI</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div id="topbar"></div>
+  <div id="layout">
+    <aside id="left-rail" class="open"></aside>
+    <main id="main"></main>
+    <aside id="assistant" class="hidden"></aside>
+  </div>
+  <div id="command-palette" class="hidden"></div>
+  <div id="toast-container"></div>
+  <script type="module" src="app.js"></script>
+</body>
 </html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,65 +1,152 @@
-/* Vibrant animated background and custom styles */
+:root {
+  --bg: #0F1115;
+  --card: #151821;
+  --muted: #1F2430;
+  --text: #E5E7EB;
+  --text-dim: #9CA3AF;
+  --accent: #22D3EE;
+  --radius-lg: 16px;
+  --radius-sm: 8px;
+  --shadow: 0 8px 30px rgba(0,0,0,.25);
+  --gap: 12px;
+}
+
+* { box-sizing: border-box; }
 body {
-  font-family: 'Poppins', sans-serif;
-  min-height: 100vh;
-  position: relative;
-  overflow: hidden;
-  --bg-image: url('https://images.unsplash.com/photo-1502672023488-70e25813eb80?auto=format&fit=crop&w=1350&q=80');
+  margin:0;
+  font-family:'Inter', sans-serif;
+  font-size:14px;
+  color:var(--text);
+  background:var(--bg);
+  height:100vh;
+  overflow:hidden;
 }
 
-/* Background image layer */
-body::before {
-  content: "";
-  position: fixed;
-  inset: 0;
-  background: center/cover no-repeat;
-  background-image: var(--bg-image);
-  filter: blur(8px);
-  z-index: -2;
+#topbar {
+  position:fixed;
+  top:0; left:0; right:0;
+  height:56px;
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  padding:0 var(--gap);
+  background:rgba(21,24,33,.6);
+  backdrop-filter:blur(10px);
+  box-shadow:var(--shadow);
+  z-index:10;
+}
+#topbar .tabs {display:flex; gap:var(--gap);}
+#topbar .right {display:flex; align-items:center; gap:var(--gap);}
+#topbar input {height:36px;}
+#topbar .avatar {width:32px;height:32px;border-radius:50%;background:var(--muted);}
+#topbar .logo {font-weight:600;}
+
+#layout {
+  display:flex;
+  position:absolute;
+  top:56px; bottom:0; left:0; right:0;
 }
 
-/* Animated gradient overlay */
-body::after {
-  content: "";
-  position: fixed;
-  inset: 0;
-  background: linear-gradient(-45deg, rgba(238,119,82,0.6), rgba(231,60,126,0.6), rgba(35,166,213,0.6), rgba(35,213,171,0.6));
-  background-size: 400% 400%;
-  animation: gradient 15s ease infinite;
-  z-index: -1;
+#left-rail {
+  width:240px;
+  background:rgba(21,24,33,.6);
+  backdrop-filter:blur(10px);
+  border-right:1px solid var(--muted);
+  padding:var(--gap);
+  overflow-y:auto;
+  transition:width 0.18s;
+}
+#left-rail.collapsed { width:60px; }
+#left-rail #collapse-rail {background:none;border:none;color:var(--text);margin-bottom:var(--gap);cursor:pointer;}
+.saved-item {cursor:pointer;padding:4px 0;}
+
+#assistant {
+  width:320px;
+  background:rgba(21,24,33,.6);
+  backdrop-filter:blur(10px);
+  border-left:1px solid var(--muted);
+  padding:var(--gap);
+  overflow-y:auto;
+  transition:transform 0.18s;
+}
+#assistant.hidden { transform:translateX(100%); }
+
+main {
+  flex:1;
+  overflow:auto;
+  padding:var(--gap);
 }
 
-@keyframes gradient {
-  0% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0% 50%;
-  }
+.tab {
+  padding:8px 12px;
+  border-radius:var(--radius-sm);
+  cursor:pointer;
+  transition:background 0.15s;
+}
+.tab.active, .tab:hover {
+  background:var(--muted);
 }
 
-/* Subtle scrollbar styling for chat area */
-#chatbot-messages::-webkit-scrollbar {
-  width: 6px;
+.chip { display:inline-block; background:var(--muted); padding:4px 8px; border-radius:var(--radius-sm); margin:2px; font-size:12px; }
+
+input, textarea, button {
+  background:var(--card);
+  color:var(--text);
+  border:1px solid var(--muted);
+  border-radius:var(--radius-sm);
+  padding:8px;
+  transition:background 0.15s, border 0.15s;
 }
-#chatbot-messages::-webkit-scrollbar-thumb {
-  background-color: rgba(107, 114, 128, 0.5); /* tailwind gray-500 */
-  border-radius: 3px;
+input:focus, textarea:focus, button:hover {
+  border-color:var(--accent);
 }
 
-/* Ensure the chatbot widget has a fixed height and scrolls internally */
-#chatbot {
-  height: 32rem;
-  max-height: 32rem;
-  display: flex;
-  flex-direction: column;
-}
+/* Views */
+.sourcing-view { display:flex; height:100%; }
+.sourcing-view #map { flex:1; margin-right:var(--gap); background:var(--card); border-radius:var(--radius-lg); display:flex; align-items:center; justify-content:center; }
+.sourcing-view #grid { flex:1; }
 
-#chatbot-messages {
-  flex: 1;
-  overflow-y: auto;
-}
+.data {width:100%; border-collapse:collapse;}
+.data th, .data td {padding:8px; border-bottom:1px solid var(--muted); text-align:left;}
+.data tr:hover {background:var(--muted);}
 
+.kanban { display:flex; gap:var(--gap); height:100%; }
+.kanban-column { flex:1; background:var(--card); border-radius:var(--radius-lg); padding:var(--gap); display:flex; flex-direction:column; }
+.kanban-column h3 { margin-top:0; font-size:14px; }
+.lead-card { background:var(--muted); border-radius:var(--radius-sm); padding:var(--gap); margin-bottom:var(--gap); cursor:grab; }
+
+.outreach-view { display:flex; height:100%; gap:var(--gap); }
+.cohorts { width:220px; background:var(--card); border-radius:var(--radius-lg); padding:var(--gap); overflow-y:auto; }
+.editor { flex:1; display:flex; flex-direction:column; gap:var(--gap); }
+.editor textarea { flex:1; }
+.timeline { height:120px; background:var(--card); border-radius:var(--radius-lg); padding:var(--gap); overflow-y:auto; }
+
+/* Command palette */
+#command-palette {
+  position:fixed; inset:0; display:flex; align-items:flex-start; justify-content:center; padding-top:10%; background:rgba(0,0,0,.4); backdrop-filter:blur(2px);
+}
+#command-palette.hidden { display:none; }
+.cp-box { width:400px; background:var(--card); border-radius:var(--radius-lg); box-shadow:var(--shadow); padding:var(--gap); display:flex; flex-direction:column; }
+.cp-box input { margin-bottom:var(--gap); }
+.cp-list { max-height:300px; overflow:auto; }
+.cp-item { padding:8px; border-radius:var(--radius-sm); cursor:pointer; }
+.cp-item.active, .cp-item:hover { background:var(--muted); }
+
+/* Toast */
+#toast-container { position:fixed; bottom:var(--gap); right:var(--gap); display:flex; flex-direction:column; gap:var(--gap); }
+.toast { background:var(--card); padding:var(--gap); border-radius:var(--radius-sm); box-shadow:var(--shadow); opacity:0; animation:fadein 0.2s forwards, fadeout 0.2s forwards 2.8s; }
+@keyframes fadein { from { opacity:0; transform:translateY(10px); } to {opacity:1; transform:translateY(0);} }
+@keyframes fadeout { to {opacity:0; transform:translateY(10px);} }
+
+/* Skeleton */
+.skeleton { background:linear-gradient(90deg,var(--muted),#2a303f,var(--muted)); background-size:200% 100%; animation:shimmer 1.2s infinite; border-radius:var(--radius-sm); }
+@keyframes shimmer { from { background-position:200% 0; } to { background-position:-200% 0; } }
+.skeleton.row { height:44px; margin-bottom:var(--gap); }
+.skeleton.card { height:60px; margin-bottom:var(--gap); }
+
+/* Responsive */
+@media (max-width:1024px) {
+  #left-rail { display:none; }
+  .sourcing-view { flex-direction:column; }
+  .sourcing-view #map { margin-right:0; margin-bottom:var(--gap); height:200px; }
+}


### PR DESCRIPTION
## Summary
- implement dark glass-themed SPA scaffold with topbar, left rail, assistant drawer, command palette
- add sourcing data grid, leads kanban board with drag-and-drop and toast notifications
- include outreach view, skeleton loaders, and mock data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896622f237483268fa04800af9fc29e