### PR TITLE
Enhance chat window styling with background and glow

### DIFF
--- a/frontend/chat-bg.svg
+++ b/frontend/chat-bg.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="600">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1e3c72"/>
+      <stop offset="100%" stop-color="#2a5298"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="600" fill="url(#g)"/>
+</svg>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -125,18 +125,24 @@ input:focus, textarea:focus, button:hover {
 .agent-chat { display:flex; align-items:center; justify-content:center; height:100%; }
 .chat-box {
   width:400px;
-  max-width:100%;
-  background:rgba(21,24,33,.6);
-  backdrop-filter:blur(10px);
+  height:600px;
+  background:transparent;
+  background-image:url('./chat-bg.svg');
+  background-size:cover;
+  background-position:center;
   border:1px solid var(--muted);
   border-radius:var(--radius-lg);
   box-shadow:var(--shadow);
   display:flex;
   flex-direction:column;
+  transition:box-shadow 0.3s;
 }
-.chat-messages { flex:1; padding:var(--gap); overflow-y:auto; }
-.chat-form { display:flex; gap:var(--gap); padding:var(--gap); border-top:1px solid var(--muted); }
-.chat-form input { flex:1; }
+.chat-box:hover { box-shadow:0 0 15px var(--accent); }
+.chat-messages { flex:1; padding:var(--gap); overflow-y:auto; background:transparent; }
+.chat-form { display:flex; gap:var(--gap); padding:var(--gap); border-top:1px solid var(--muted); background:transparent; }
+.chat-form input { flex:1; background:transparent; transition:box-shadow 0.3s, border 0.3s; }
+.chat-form button { background:transparent; transition:box-shadow 0.3s, border 0.3s; }
+.chat-form input:hover, .chat-form button:hover { box-shadow:0 0 8px var(--accent); border-color:var(--accent); }
 .msg { margin-bottom:var(--gap); }
 .msg.user { text-align:right; }
 


### PR DESCRIPTION
## Summary
- add gradient SVG background for chat window
- make chat box and form elements transparent
- add hover glow effects and fixed sizing for chat window

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689667f364e883269e3837a3cc34623d