### PR TITLE
Rebrand to Cascade AI with transparent tile theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Property Listing Chatbot
+# Cascade AI
 
-This sample demonstrates how to combine Amazon Nova core models with Nova Sonic to build a multimodal real-estate assistant. The chatbot answers typed or spoken questions about sample property listings.
+This sample demonstrates how to combine Amazon Nova core models with Nova Sonic to build a multimodal real-estate assistant. The Cascade AI application answers typed or spoken questions about sample property listings.
 
 
 ## Architecture

--- a/frontend/chat-bg.svg
+++ b/frontend/chat-bg.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="600">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1e3c72"/>
+      <stop offset="100%" stop-color="#2a5298"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="600" fill="url(#g)"/>
+</svg>

--- a/frontend/components/topbar.js
+++ b/frontend/components/topbar.js
@@ -1,7 +1,7 @@
 export function initTopbar() {
   const bar = document.getElementById('topbar');
   bar.innerHTML = `
-    <div class="logo">EstateAI</div>
+    <div class="logo">Cascade AI</div>
     <div class="tabs">
       <span class="tab" data-route="#/sourcing">Sourcing</span>
       <span class="tab" data-route="#/leads">Leads</span>

--- a/frontend/global-bg.svg
+++ b/frontend/global-bg.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600">
+  <defs>
+    <linearGradient id="grad" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#e0f7ff"/>
+      <stop offset="100%" stop-color="#ffffff"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#grad)"/>
+</svg>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Real Estate AI</title>
+  <title>Cascade AI</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,9 +1,9 @@
 :root {
-  --bg: #0F1115;
-  --card: #151821;
-  --muted: #1F2430;
-  --text: #E5E7EB;
-  --text-dim: #9CA3AF;
+  --bg: #f0f0f0;
+  --card: rgba(255,255,255,0.8);
+  --muted: rgba(255,255,255,0.5);
+  --text: #111;
+  --text-dim: #555;
   --accent: #22D3EE;
   --radius-lg: 16px;
   --radius-sm: 8px;
@@ -17,7 +17,8 @@ body {
   font-family:'Inter', sans-serif;
   font-size:14px;
   color:var(--text);
-  background:var(--bg);
+  background:var(--bg) url('./global-bg.svg') no-repeat center center fixed;
+  background-size:cover;
   height:100vh;
   overflow:hidden;
 }
@@ -30,7 +31,7 @@ body {
   align-items:center;
   justify-content:space-between;
   padding:0 var(--gap);
-  background:rgba(21,24,33,.6);
+  background:var(--card);
   backdrop-filter:blur(10px);
   box-shadow:var(--shadow);
   z-index:10;
@@ -39,7 +40,8 @@ body {
 #topbar .right {display:flex; align-items:center; gap:var(--gap);}
 #topbar input {height:36px;}
 #topbar .avatar {width:32px;height:32px;border-radius:50%;background:var(--muted);}
-#topbar .logo {font-weight:600;}
+#topbar .logo {font-weight:600; cursor:pointer; transition:transform 0.3s, text-shadow 0.3s;}
+#topbar .logo:hover {transform:scale(1.1); text-shadow:0 0 12px var(--accent);}
 
 #layout {
   display:flex;
@@ -49,7 +51,7 @@ body {
 
 #left-rail {
   width:240px;
-  background:rgba(21,24,33,.6);
+  background:var(--card);
   backdrop-filter:blur(10px);
   border-right:1px solid var(--muted);
   padding:var(--gap);
@@ -62,7 +64,7 @@ body {
 
 #assistant {
   width:320px;
-  background:rgba(21,24,33,.6);
+  background:var(--card);
   backdrop-filter:blur(10px);
   border-left:1px solid var(--muted);
   padding:var(--gap);
@@ -75,6 +77,8 @@ main {
   flex:1;
   overflow:auto;
   padding:var(--gap);
+  background:var(--card);
+  border-radius:var(--radius-lg);
 }
 
 .tab {
@@ -125,24 +129,30 @@ input:focus, textarea:focus, button:hover {
 .agent-chat { display:flex; align-items:center; justify-content:center; height:100%; }
 .chat-box {
   width:400px;
-  max-width:100%;
-  background:rgba(21,24,33,.6);
-  backdrop-filter:blur(10px);
+  height:600px;
+  background:var(--card);
+  background-image:url('./chat-bg.svg');
+  background-size:cover;
+  background-position:center;
   border:1px solid var(--muted);
   border-radius:var(--radius-lg);
   box-shadow:var(--shadow);
   display:flex;
   flex-direction:column;
+  transition:box-shadow 0.3s;
 }
-.chat-messages { flex:1; padding:var(--gap); overflow-y:auto; }
-.chat-form { display:flex; gap:var(--gap); padding:var(--gap); border-top:1px solid var(--muted); }
-.chat-form input { flex:1; }
+.chat-box:hover { box-shadow:0 0 15px var(--accent); }
+.chat-messages { flex:1; padding:var(--gap); overflow-y:auto; background:transparent; }
+.chat-form { display:flex; gap:var(--gap); padding:var(--gap); border-top:1px solid var(--muted); background:transparent; }
+.chat-form input { flex:1; background:var(--muted); transition:box-shadow 0.3s, border 0.3s; }
+.chat-form button { background:var(--muted); transition:box-shadow 0.3s, border 0.3s; }
+.chat-form input:hover, .chat-form button:hover { box-shadow:0 0 8px var(--accent); border-color:var(--accent); }
 .msg { margin-bottom:var(--gap); }
 .msg.user { text-align:right; }
 
 /* Command palette */
 #command-palette {
-  position:fixed; inset:0; display:flex; align-items:flex-start; justify-content:center; padding-top:10%; background:rgba(0,0,0,.4); backdrop-filter:blur(2px);
+  position:fixed; inset:0; display:flex; align-items:flex-start; justify-content:center; padding-top:10%; background:rgba(255,255,255,.4); backdrop-filter:blur(2px);
 }
 #command-palette.hidden { display:none; }
 .cp-box { width:400px; background:var(--card); border-radius:var(--radius-lg); box-shadow:var(--shadow); padding:var(--gap); display:flex; flex-direction:column; }
@@ -158,7 +168,7 @@ input:focus, textarea:focus, button:hover {
 @keyframes fadeout { to {opacity:0; transform:translateY(10px);} }
 
 /* Skeleton */
-.skeleton { background:linear-gradient(90deg,var(--muted),#2a303f,var(--muted)); background-size:200% 100%; animation:shimmer 1.2s infinite; border-radius:var(--radius-sm); }
+.skeleton { background:linear-gradient(90deg,var(--muted),#d0d0d0,var(--muted)); background-size:200% 100%; animation:shimmer 1.2s infinite; border-radius:var(--radius-sm); }
 @keyframes shimmer { from { background-position:200% 0; } to { background-position:-200% 0; } }
 .skeleton.row { height:44px; margin-bottom:var(--gap); }
 .skeleton.card { height:60px; margin-bottom:var(--gap); }


### PR DESCRIPTION
## Summary
- Rename app to Cascade AI and animate the logo on hover
- Add a global gradient background and semi-transparent white tile styling across the interface
- Style chat controls with matching translucent aesthetics

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689667f364e883269e3837a3cc34623d