### PR TITLE
Improve chatbot UI aesthetics

### DIFF
--- a/frontend/components/agent-chat.js
+++ b/frontend/components/agent-chat.js
@@ -5,7 +5,7 @@ export function createAgentChat() {
     <div class="chat-box">
       <div id="chat-messages" class="chat-messages"></div>
       <form id="chat-form" class="chat-form">
-        <input id="chat-input" placeholder="Ask about properties..." autocomplete="off" />
+        <input id="chat-input" placeholder="Type your message..." autocomplete="off" />
         <button type="submit">Send</button>
       </form>
     </div>
@@ -37,7 +37,9 @@ export function createAgentChat() {
   function addMessage(role, text) {
     const div = document.createElement('div');
     div.className = `msg ${role}`;
-    div.textContent = text;
+    const span = document.createElement('span');
+    span.textContent = text;
+    div.appendChild(span);
     messages.appendChild(div);
     messages.scrollTop = messages.scrollHeight;
   }

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,13 +1,13 @@
 :root {
-  --bg: #f0f0f0;
-  --card: rgba(255,255,255,0.8);
-  --muted: rgba(255,255,255,0.5);
-  --text: #111;
-  --text-dim: #555;
-  --accent: #22D3EE;
+  --bg: #f9fafb;
+  --card: rgba(255,255,255,0.9);
+  --muted: #e5e7eb;
+  --text: #111827;
+  --text-dim: #6b7280;
+  --accent: #3b82f6;
   --radius-lg: 16px;
   --radius-sm: 8px;
-  --shadow: 0 8px 30px rgba(0,0,0,.25);
+  --shadow: 0 2px 12px rgba(0,0,0,0.1);
   --gap: 12px;
 }
 
@@ -27,9 +27,7 @@ body::before {
   content:"";
   position:fixed;
   inset:0;
-  background:url('./apartment-bg.svg') no-repeat center center;
-  background-size:cover;
-  filter:blur(8px);
+  background:url('./global-bg.svg') no-repeat center center/cover;
   z-index:-1;
 }
 
@@ -152,22 +150,58 @@ input:focus, textarea:focus, button:hover {
 .chat-box {
   width:400px;
   height:600px;
-  background:rgba(255,255,255,0.2);
-  backdrop-filter:blur(10px);
+  background:var(--card);
   border:1px solid var(--muted);
   border-radius:var(--radius-lg);
   box-shadow:var(--shadow);
   display:flex;
   flex-direction:column;
+  overflow:hidden;
   transition:box-shadow 0.3s;
 }
 .chat-box:hover { box-shadow:0 0 15px var(--accent); }
-.chat-messages { flex:1; padding:var(--gap); overflow-y:auto; background:transparent; }
-.chat-form { display:flex; gap:var(--gap); padding:var(--gap); border-top:1px solid var(--muted); background:transparent; }
+.chat-messages {
+  flex:1;
+  padding:var(--gap);
+  overflow-y:auto;
+  background:var(--card);
+}
+.chat-form {
+  display:flex;
+  gap:var(--gap);
+  padding:var(--gap);
+  border-top:1px solid var(--muted);
+  background:var(--card);
+}
+.chat-form input { flex:1; }
+.chat-form button {
+  background:var(--accent);
+  color:white;
+  border:none;
+  cursor:pointer;
+  transition:filter 0.2s;
+}
+.chat-form button:hover { filter:brightness(0.9); }
+.msg {
+  margin-bottom:var(--gap);
+  display:flex;
+}
+.msg span {
+  padding:8px 12px;
+  border-radius:var(--radius-lg);
+  max-width:80%;
+  box-shadow:0 1px 2px rgba(0,0,0,0.1);
+  animation:slide-up 0.2s ease;
+}
+.msg.bot { justify-content:flex-start; }
+.msg.bot span { background:var(--muted); color:var(--text); }
+.msg.user { justify-content:flex-end; }
+.msg.user span { background:var(--accent); color:white; }
 
-.chat-form input:hover, .chat-form button:hover { box-shadow:0 0 8px var(--accent); border-color:var(--accent); }
-.msg { margin-bottom:var(--gap); }
-.msg.user { text-align:right; }
+@keyframes slide-up {
+  from { opacity:0; transform:translateY(4px); }
+  to { opacity:1; transform:translateY(0); }
+}
 
 /* Command palette */
 #command-palette {


### PR DESCRIPTION
## Summary
- Refresh global color palette and backgrounds for a cleaner, modern look
- Add message bubble styling and animated transitions to the agent chat
- Simplify chat input form for a more standard messaging experience

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899ff76f92c8326b227df9503223660