### PR TITLE
feat: expand layout and add map markers

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -10,6 +10,9 @@ import { createAgentChat } from './components/agent-chat.js';
 const state={ data:{} };
 let topbarAPI;
 
+const backgrounds=['global-bg.svg','apartment-bg.svg','chat-bg.svg'];
+let bgIndex=0;
+
 fetch('data/sample.json').then(r=>r.json()).then(d=>{state.data=d;init();});
 
 function init(){
@@ -21,6 +24,7 @@ function init(){
   window.addEventListener('hashchange',router);
   router();
   setupShortcuts();
+  setupBackground();
 }
 
 function router(){
@@ -31,10 +35,19 @@ function router(){
     topbarAPI.setActive('#/sourcing');
     const wrap=document.createElement('div');
     wrap.className='sourcing-view';
-    const map=document.createElement('div');map.id='map';map.textContent='Map';
+    const map=document.createElement('div');map.id='map';
     const grid=createDataGrid(state.data.properties||[]);
     wrap.append(map,grid);
     main.appendChild(wrap);
+    if(window.google&&window.google.maps&&state.data.properties&&state.data.properties.length){
+      const first=state.data.properties[0];
+      const gmap=new google.maps.Map(map,{center:{lat:first.lat,lng:first.lng},zoom:10});
+      state.data.properties.forEach(p=>{
+        if(p.lat&&p.lng){
+          new google.maps.Marker({position:{lat:p.lat,lng:p.lng},map:gmap,title:p.address});
+        }
+      });
+    }
   } else if(hash.startsWith('#/leads')){
     topbarAPI.setActive('#/leads');
     const board=createKanban(state.data.leads||[]);
@@ -67,4 +80,18 @@ function setupShortcuts(){
     if((e.ctrlKey||e.metaKey) && e.key.toLowerCase()==='k'){ e.preventDefault(); togglePalette(); }
     if(e.key.toLowerCase()==='a' && !e.ctrlKey && !e.metaKey){ e.preventDefault(); toggleAssistant(); }
   });
+}
+
+function setupBackground(){
+  const bg=document.getElementById('bg');
+  if(!bg) return;
+  bg.style.backgroundImage=`url('${backgrounds[0]}')`;
+  setInterval(()=>{
+    bg.style.opacity=0;
+    setTimeout(()=>{
+      bgIndex=(bgIndex+1)%backgrounds.length;
+      bg.style.backgroundImage=`url('${backgrounds[bgIndex]}')`;
+      bg.style.opacity=1;
+    },1000);
+  },10000);
 }

--- a/frontend/data/sample.json
+++ b/frontend/data/sample.json
@@ -1,8 +1,8 @@
 {
   "properties": [
-    {"id":1,"address":"123 Main St","price":"$500k"},
-    {"id":2,"address":"456 Oak Ave","price":"$750k"},
-    {"id":3,"address":"789 Pine Dr","price":"$1.2M"}
+    {"id":1,"address":"123 Main St","price":"$500k","lat":47.6062,"lng":-122.3321},
+    {"id":2,"address":"456 Oak Ave","price":"$750k","lat":45.5122,"lng":-122.6587},
+    {"id":3,"address":"789 Pine Dr","price":"$1.2M","lat":37.7749,"lng":-122.4194}
   ],
   "leads": [
     {"id":1,"name":"Alice","stage":"New"},

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+  <div id="bg"></div>
   <div id="topbar"></div>
   <div id="layout">
     <aside id="left-rail"></aside>
@@ -18,6 +19,7 @@
   </div>
   <div id="command-palette" class="hidden"></div>
   <div id="toast-container"></div>
+  <script async src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY"></script>
   <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -23,12 +23,14 @@ body {
   position:relative;
 }
 
-body::before {
-  content:"";
+#bg {
   position:fixed;
   inset:0;
-  background:url('./global-bg.svg') no-repeat center center/cover;
+  background-size:cover;
+  background-position:center;
   z-index:-1;
+  opacity:1;
+  transition:opacity 1s ease-in-out;
 }
 
 #topbar {
@@ -96,6 +98,8 @@ main {
 }
 main:hover { box-shadow:0 0 15px var(--accent); }
 
+main > * { width:100%; }
+
 .tab {
   padding:8px 12px;
   border-radius:var(--radius-sm);
@@ -124,9 +128,9 @@ input:focus, textarea:focus, button:hover {
 }
 
 /* Views */
-.sourcing-view { display:flex; height:100%; }
-.sourcing-view #map { flex:1; margin-right:var(--gap); background:var(--card); border-radius:var(--radius-lg); display:flex; align-items:center; justify-content:center; }
-.sourcing-view #grid { flex:1; }
+.sourcing-view { display:flex; flex-direction:column; height:100%; }
+.sourcing-view #map { width:100%; margin-right:0; margin-bottom:var(--gap); background:var(--card); border-radius:var(--radius-lg); display:flex; align-items:center; justify-content:center; height:300px; }
+.sourcing-view #grid { width:100%; }
 
 .data {width:100%; border-collapse:collapse;}
 .data th, .data td {padding:8px; border-bottom:1px solid var(--muted); text-align:left;}
@@ -146,10 +150,12 @@ input:focus, textarea:focus, button:hover {
 .timeline { height:120px; background:var(--card); border-radius:var(--radius-lg); padding:var(--gap); overflow-y:auto; }
 
 /* Agent chat */
-.agent-chat { display:flex; align-items:center; justify-content:center; height:100%; }
+.agent-chat { display:flex; align-items:center; justify-content:center; height:100%; width:100%; }
 .chat-box {
-  width:400px;
-  height:600px;
+  width:100%;
+  max-width:800px;
+  height:700px;
+  max-height:100%;
   background:var(--card);
   border:1px solid var(--muted);
   border-radius:var(--radius-lg);
@@ -229,6 +235,5 @@ input:focus, textarea:focus, button:hover {
 /* Responsive */
 @media (max-width:1024px) {
   #left-rail { display:none; }
-  .sourcing-view { flex-direction:column; }
-  .sourcing-view #map { margin-right:0; margin-bottom:var(--gap); height:200px; }
+  .sourcing-view #map { height:200px; }
 }


### PR DESCRIPTION
## Summary
- Ensure main views stretch full width and enlarge agent chat experience
- Rotate shared background image with fading transitions
- Display property markers on sourcing page using Google Maps

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a0233454483268b97e4b1103a893d