### PR TITLE
Add blurred real-estate background images

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -22,7 +22,8 @@ if (window.GOOGLE_MAPS_API_KEY) {
 const state={ data:{} };
 let topbarAPI;
 
-const backgrounds=['global-bg.svg','apartment-bg.svg','chat-bg.svg'];
+// cycle through simple real-estate themed backgrounds
+const backgrounds=['property1.svg','property2.svg','property3.svg'];
 let bgIndex=0;
 
 fetch('data/sample.json').then(r=>r.json()).then(d=>{state.data=d;init();});

--- a/frontend/property1.svg
+++ b/frontend/property1.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600">
+  <rect width="800" height="600" fill="#c8e6c9"/>
+  <polygon points="400,100 150,300 650,300" fill="#8d6e63"/>
+  <rect x="250" y="300" width="300" height="200" fill="#a1887f"/>
+  <rect x="375" y="360" width="50" height="140" fill="#5d4037"/>
+  <rect x="290" y="340" width="60" height="60" fill="#fff"/>
+  <rect x="450" y="340" width="60" height="60" fill="#fff"/>
+</svg>

--- a/frontend/property2.svg
+++ b/frontend/property2.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600">
+  <rect width="800" height="600" fill="#bbdefb"/>
+  <rect x="250" y="150" width="300" height="400" fill="#90a4ae"/>
+  <rect x="250" y="150" width="300" height="40" fill="#78909c"/>
+  <g fill="#e0f7fa">
+    <rect x="280" y="210" width="50" height="50"/>
+    <rect x="370" y="210" width="50" height="50"/>
+    <rect x="460" y="210" width="50" height="50"/>
+    <rect x="280" y="290" width="50" height="50"/>
+    <rect x="370" y="290" width="50" height="50"/>
+    <rect x="460" y="290" width="50" height="50"/>
+    <rect x="280" y="370" width="50" height="50"/>
+    <rect x="370" y="370" width="50" height="50"/>
+    <rect x="460" y="370" width="50" height="50"/>
+    <rect x="280" y="450" width="50" height="50"/>
+    <rect x="370" y="450" width="50" height="50"/>
+    <rect x="460" y="450" width="50" height="50"/>
+  </g>
+</svg>

--- a/frontend/property3.svg
+++ b/frontend/property3.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600">
+  <rect width="800" height="600" fill="#ffecb3"/>
+  <polygon points="200,200 100,300 300,300" fill="#ff8a65"/>
+  <rect x="130" y="300" width="140" height="120" fill="#ff7043"/>
+  <rect x="180" y="340" width="40" height="80" fill="#fff"/>
+  <polygon points="600,250 500,330 700,330" fill="#4db6ac"/>
+  <rect x="540" y="330" width="120" height="100" fill="#26a69a"/>
+  <rect x="580" y="360" width="40" height="70" fill="#fff"/>
+</svg>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -30,6 +30,7 @@ body {
   background-position:center;
   z-index:-1;
   opacity:1;
+  filter:blur(8px);
   transition:opacity 1s ease-in-out;
 }
 
@@ -38,8 +39,8 @@ body {
 }
 
 @keyframes bg-change {
-  from {transform:scale(1.1); filter:blur(2px);}
-  to {transform:scale(1); filter:blur(0);}
+  from {transform:scale(1.1);}
+  to {transform:scale(1);}
 }
 
 #topbar {


### PR DESCRIPTION
## Summary
- Replace generic backgrounds with simple real-estate-themed SVGs
- Blur background layer for a softer visual effect

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a0bcda93c8326b8be4f058f86dd92