### PR TITLE
Add property and lead management features

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -49,8 +49,22 @@ function router(){
     const wrap=document.createElement('div');
     wrap.className='sourcing-view';
     const map=document.createElement('div');map.id='map';
+    const addBtn=document.createElement('button');
+    addBtn.textContent='Add Property';
+    addBtn.addEventListener('click',()=>{
+      const address=prompt('Address?');
+      const price=prompt('Price?');
+      const lat=parseFloat(prompt('Latitude?'));
+      const lng=parseFloat(prompt('Longitude?'));
+      if(address&&price&&!isNaN(lat)&&!isNaN(lng)){
+        const id=Date.now();
+        state.data.properties=state.data.properties||[];
+        state.data.properties.push({id,address,price,lat,lng});
+        router();
+      }
+    });
     const grid=createDataGrid(state.data.properties||[]);
-    wrap.append(map,grid);
+    wrap.append(map,addBtn,grid);
     main.appendChild(wrap);
     if(window.google&&window.google.maps&&state.data.properties&&state.data.properties.length){
       const first=state.data.properties[0];
@@ -63,7 +77,14 @@ function router(){
     }
   } else if(hash.startsWith('#/leads')){
     topbarAPI.setActive('#/leads');
-    const board=createKanban(state.data.leads||[]);
+    const board=createKanban(state.data.leads||[],{
+      onAdd:l=>{state.data.leads.push(l);router();},
+      onEdit:l=>{
+        const i=state.data.leads.findIndex(x=>x.id===l.id);
+        if(i>-1) state.data.leads[i]=l; else state.data.leads.push(l);
+        router();
+      }
+    });
     main.appendChild(board);
   } else if(hash.startsWith('#/outreach')){
     topbarAPI.setActive('#/outreach');

--- a/frontend/components/kanban.js
+++ b/frontend/components/kanban.js
@@ -3,9 +3,19 @@ import { showToast } from './toast.js';
 
 const stages=['New','Contacted','Qualified','Proposal','Closed'];
 
-export function createKanban(leads=[]) {
+export function createKanban(leads=[],callbacks={}) {
+  const {onAdd,onEdit}=callbacks;
   const board=document.createElement('div');
   board.className='kanban';
+  const controls=document.createElement('div');
+  const addBtn=document.createElement('button');
+  addBtn.textContent='Add Lead';
+  addBtn.addEventListener('click',()=>{
+    const name=prompt('Lead name?');
+    if(name){ const id=Date.now(); if(onAdd) onAdd({id,name,stage:'New'}); }
+  });
+  controls.appendChild(addBtn);
+  board.appendChild(controls);
   const columns={};
   stages.forEach(s=>{
     const col=document.createElement('div');
@@ -20,6 +30,7 @@ export function createKanban(leads=[]) {
       const card=document.getElementById(id);
       col.appendChild(card);
       showToast(`Moved ${card.dataset.name} to ${s}`);
+      if(onEdit){ const leadId=parseInt(id.replace('lead-','')); onEdit({id:leadId,name:card.dataset.name,stage:s}); }
     });
     board.appendChild(col);
     columns[s]=col;
@@ -35,6 +46,12 @@ export function createKanban(leads=[]) {
       card.dataset.name=l.name;
       card.innerText=l.name;
       card.addEventListener('dragstart',e=>e.dataTransfer.setData('id',card.id));
+      card.addEventListener('dblclick',()=>{
+        const name=prompt('Lead name',l.name);
+        if(!name) return;
+        const stage=prompt('Stage',l.stage)||l.stage;
+        if(onEdit){ onEdit({id:l.id,name,stage:stages.includes(stage)?stage:l.stage}); }
+      });
       columns[l.stage].appendChild(card);
     });
   }


### PR DESCRIPTION
## Summary
- Allow adding properties with coordinates, updating map and grid
- Enable adding and editing leads in kanban view

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m py_compile backend/*.py`


------
https://chatgpt.com/codex/tasks/task_e_689a155672588326b7fcafd12d2eb3d5