### PR TITLE
Add interactive property selection on sourcing map

### DIFF
--- a/frontend/components/datagrid.js
+++ b/frontend/components/datagrid.js
@@ -1,16 +1,27 @@
 import { skeletonRow } from './skeleton.js';
 
-export function createDataGrid(props=[]) {
+export function createDataGrid(props = [], onSelect) {
   const el = document.createElement('div');
-  el.id='grid';
+  el.id = 'grid';
   const sk = document.createElement('div');
-  for(let i=0;i<5;i++) sk.appendChild(skeletonRow());
+  for (let i = 0; i < 5; i++) sk.appendChild(skeletonRow());
   el.appendChild(sk);
-  setTimeout(()=>render(),800);
-  function render(){
-    el.innerHTML = `<table class="data"><thead><tr><th>Address</th><th>Price</th></tr></thead><tbody>`+
-      props.map(p=>`<tr><td>${p.address}</td><td>${p.price}</td></tr>`).join('')+
+  setTimeout(() => render(), 800);
+  function render() {
+    el.innerHTML =
+      `<table class="data"><thead><tr><th>Address</th><th>Price</th></tr></thead><tbody>` +
+      props
+        .map(
+          (p) =>
+            `<tr data-prop-id="${p.id}"><td>${p.address}</td><td>${p.price}</td></tr>`
+        )
+        .join('') +
       `</tbody></table>`;
   }
+  el.addEventListener('click', (e) => {
+    const row = e.target.closest('tr[data-prop-id]');
+    if (!row) return;
+    if (onSelect) onSelect(row.dataset.propId);
+  });
   return el;
 }

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -156,6 +156,7 @@ button:hover{
 .data {width:100%; border-collapse:collapse;}
 .data th, .data td {padding:8px; border-bottom:1px solid var(--muted); text-align:left; background-color: rgb(255, 255, 255,0.6);}
 .data tr:hover {background:var(--muted);}
+.data tr.active {background:rgba(59,130,246,0.2);}
 
 .kanban { display:flex; gap:var(--gap); height:100%; }
 .kanban-column { flex:1; background:var(--card); border-radius:var(--radius-lg); padding:var(--gap); display:flex; flex-direction:column; }


### PR DESCRIPTION
## Summary
- Track Google Map instance, markers, and info window in global state
- Render markers for properties and allow selecting a property from list or marker
- Highlight selected property row and display info bubble

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a30895c208326b5acb816440b8fa6