### PR TITLE
Handle missing property prices

### DIFF
--- a/backend/property_chatbot.py
+++ b/backend/property_chatbot.py
@@ -461,7 +461,15 @@ async def process_user_query(query: str):
         {
             "image": p.get("image", "https://placehold.co/400x300"),
             "address": p.get("address") or p.get("location"),
-            "price": f"${p.get('price'):,}",
+            # ``price`` may be ``None`` when the source data is missing a value.
+            # Formatting ``None`` with ``:,`` raises ``TypeError`` which used to
+            # crash the request handler.  Provide a human friendly placeholder
+            # instead so the web API remains robust regardless of data quality.
+            "price": (
+                f"${p.get('price'):,}"
+                if isinstance(p.get("price"), (int, float))
+                else "N/A"
+            ),
             "description": p.get("description", "")
         }
         for p in listings
@@ -476,7 +484,11 @@ async def process_user_audio(audio_bytes: bytes):
         {
             "image": p.get("image", "https://placehold.co/400x300"),
             "address": p.get("address") or p.get("location"),
-            "price": f"${p.get('price'):,}",
+            "price": (
+                f"${p.get('price'):,}"
+                if isinstance(p.get("price"), (int, float))
+                else "N/A"
+            ),
             "description": p.get("description", ""),
         }
         for p in result["listings"]

--- a/tests/test_price_format.py
+++ b/tests/test_price_format.py
@@ -1,0 +1,24 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the project root is on ``sys.path`` so the ``backend`` package can be
+# imported when tests are executed from the ``tests`` directory.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from backend.property_chatbot import _bot, process_user_query
+
+
+def test_process_user_query_handles_missing_price(monkeypatch):
+    """Listings lacking a price should not crash the request handler."""
+    # Simulate retriever returning a listing without a price
+    fake_listing = {"address": "123 Anywhere St", "price": None, "description": ""}
+    monkeypatch.setattr(_bot.retriever, "search", lambda q, limit=3: [fake_listing])
+    # Avoid invoking the real LLM which requires external credentials
+    monkeypatch.setattr(_bot.llm, "answer", lambda question, listings: "ok")
+
+    res = asyncio.run(process_user_query("property?"))
+    assert res["properties"][0]["price"] == "N/A"
+    assert res["reply"] == "ok"


### PR DESCRIPTION
## Summary
- Avoid TypeError when property data lacks a price by providing `N/A`
- Added regression test for missing price handling
- Expose backend as importable package

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a556d57f48326adfc5ab25e03d471