### PR TITLE
Improve chat cards and history

### DIFF
--- a/backend/langgraph_app.py
+++ b/backend/langgraph_app.py
@@ -154,6 +154,7 @@ async def format_agent(state: GraphState) -> GraphState:
     )
     cards = [
         {
+            "id": p.get("id"),
             "address": p.get("address"),
             "price": (
                 f"${p.get('price'):,}"

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -83,6 +83,8 @@ function router(){
       }
     });
     const props=state.data.properties||[];
+    const params=new URLSearchParams(query||'');
+    const initialProp=params.get('prop');
     function selectProperty(id){
       if(!state.gmap) return;
       const p=(state.data.properties||[]).find(x=>String(x.id)===String(id));
@@ -178,6 +180,7 @@ function router(){
       });
       if(props.length>1){state.gmap.fitBounds(bounds);}
     }
+    if(initialProp){ selectProperty(initialProp); }
     } else if(route.startsWith('#/leads')){
       topbarAPI.setActive('#/leads');
       const params=new URLSearchParams(query||'');

--- a/frontend/components/agent-chat.js
+++ b/frontend/components/agent-chat.js
@@ -1,3 +1,5 @@
+const history = [];
+
 export function createAgentChat() {
   const wrap = document.createElement('div');
   wrap.className = 'agent-chat';
@@ -15,6 +17,9 @@ export function createAgentChat() {
   const input = wrap.querySelector('#chat-input');
   const messages = wrap.querySelector('#chat-messages');
 
+  // Render any previous chat history
+  history.forEach(m => renderMessage(m));
+
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
     const text = input.value.trim();
@@ -25,21 +30,46 @@ export function createAgentChat() {
       const resp = await fetch('http://localhost:8000/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text: text })
+        body: JSON.stringify({ text })
       });
       const data = await resp.json();
-      addMessage('bot', data.answer || 'No reply');
+      addMessage('bot', data.reply || data.answer || 'No reply', data.properties);
     } catch (err) {
       addMessage('bot', 'Error contacting server');
     }
   });
 
-  function addMessage(role, text) {
+  function addMessage(role, text, properties = []) {
+    const msg = { role, text, properties };
+    history.push(msg);
+    renderMessage(msg);
+  }
+
+  function renderMessage({ role, text, properties }) {
     const div = document.createElement('div');
     div.className = `msg ${role}`;
     const span = document.createElement('span');
     span.textContent = text;
+    span.style.whiteSpace = 'pre-wrap';
     div.appendChild(span);
+
+    if (Array.isArray(properties) && properties.length) {
+      const list = document.createElement('div');
+      list.className = 'prop-cards';
+      properties.forEach(p => {
+        const card = document.createElement('div');
+        card.className = 'prop-card';
+        card.innerHTML = `<strong>${p.address || ''}</strong><br/>${p.price || ''}<br/>${p.description || ''}`;
+        if (p.id) {
+          card.addEventListener('click', () => {
+            location.hash = `#/sourcing?prop=${p.id}`;
+          });
+        }
+        list.appendChild(card);
+      });
+      div.appendChild(list);
+    }
+
     messages.appendChild(div);
     messages.scrollTop = messages.scrollHeight;
   }

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -230,6 +230,10 @@ button:hover{
 .msg.user { justify-content:flex-end; }
 .msg.user span { background:var(--accent); color:white; }
 
+.prop-cards { margin-top:var(--gap); display:flex; flex-direction:column; gap:var(--gap); }
+.prop-card { background:var(--muted); padding:var(--gap); border-radius:var(--radius-sm); cursor:pointer; box-shadow:var(--shadow); }
+.prop-card:hover { background:var(--card); }
+
 @keyframes slide-up {
   from { opacity:0; transform:translateY(4px); }
   to { opacity:1; transform:translateY(0); }


### PR DESCRIPTION
## Summary
- Return property IDs from formatting agent
- Render property cards in chat with navigation to sourcing view
- Preserve chat history and format messages with line breaks
- Allow sourcing route to preselect property via query parameter
- Add basic styling for property cards

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a63b1542483268942ee6df3f9f5ea