### PR TITLE
feat: display property cards with sourcing links

### DIFF
--- a/backend/langgraph_app.py
+++ b/backend/langgraph_app.py
@@ -155,6 +155,7 @@ async def format_agent(state: GraphState) -> GraphState:
     cards = [
         {
             "id": p.get("id"),
+            "image": p.get("image", "https://placehold.co/400x300"),
             "address": p.get("address"),
             "price": (
                 f"${p.get('price'):,}"

--- a/backend/property_chatbot.py
+++ b/backend/property_chatbot.py
@@ -466,6 +466,7 @@ async def process_user_query(query: str):
     answer, listings = _bot.ask_text(query)
     cards = [
         {
+            "id": p.get("id"),
             "image": p.get("image", "https://placehold.co/400x300"),
             "address": p.get("address") or p.get("location"),
             # ``price`` may be ``None`` when the source data is missing a value.
@@ -489,6 +490,7 @@ async def process_user_audio(audio_bytes: bytes):
     result = _bot.ask_audio(audio_bytes)
     cards = [
         {
+            "id": p.get("id"),
             "image": p.get("image", "https://placehold.co/400x300"),
             "address": p.get("address") or p.get("location"),
             "price": (

--- a/frontend/components/agent-chat.js
+++ b/frontend/components/agent-chat.js
@@ -59,12 +59,27 @@ export function createAgentChat() {
       properties.forEach(p => {
         const card = document.createElement('div');
         card.className = 'prop-card';
-        card.innerHTML = `<strong>${p.address || ''}</strong><br/>${p.price || ''}<br/>${p.description || ''}`;
+
+        const img = document.createElement('img');
+        img.src = p.image || 'https://placehold.co/400x300';
+        img.alt = p.address || 'Property image';
+
+        const info = document.createElement('div');
+        info.className = 'details';
+        info.innerHTML = `<strong>${p.address || ''}</strong><br/>${p.price || ''}<br/>${p.description || ''}`;
+
         if (p.id) {
-          card.addEventListener('click', () => {
+          const btn = document.createElement('button');
+          btn.textContent = 'Show Property';
+          btn.addEventListener('click', () => {
             location.hash = `#/sourcing?prop=${p.id}`;
           });
+          info.appendChild(document.createElement('br'));
+          info.appendChild(btn);
         }
+
+        card.appendChild(img);
+        card.appendChild(info);
         list.appendChild(card);
       });
       div.appendChild(list);

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -231,7 +231,23 @@ button:hover{
 .msg.user span { background:var(--accent); color:white; }
 
 .prop-cards { margin-top:var(--gap); display:flex; flex-direction:column; gap:var(--gap); }
-.prop-card { background:var(--muted); padding:var(--gap); border-radius:var(--radius-sm); cursor:pointer; box-shadow:var(--shadow); }
+.prop-card {
+  display:flex;
+  gap:var(--gap);
+  background:var(--muted);
+  padding:var(--gap);
+  border-radius:var(--radius-sm);
+  box-shadow:var(--shadow);
+  align-items:flex-start;
+}
+.prop-card img {
+  width:80px;
+  height:60px;
+  object-fit:cover;
+  border-radius:var(--radius-sm);
+}
+.prop-card .details { flex:1; }
+.prop-card button { margin-top:var(--gap); }
 .prop-card:hover { background:var(--card); }
 
 @keyframes slide-up {


### PR DESCRIPTION
## Summary
- present property suggestions as card with image and Show Property button
- style property cards for visual layout
- include property identifiers and images in chat responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689a667450308326a7e0bd1588c11221