### PR TITLE
Add keyword fallback for property query classification

### DIFF
--- a/backend/langgraph_app.py
+++ b/backend/langgraph_app.py
@@ -123,7 +123,18 @@ async def query_classifier_agent(state: GraphState) -> GraphState:
         is_query = output.startswith("y")
     except (KeyError, IndexError, TypeError, NoCredentialsError, ClientError) as exc:
         logger.warning("query_classifier_agent failed: %s", exc)
-        is_query = False
+        # Fall back to a simple keyword check when the LLM is unavailable
+        text = state.get("user_input", "").lower()
+        keywords = [
+            "house",
+            "home",
+            "apartment",
+            "property",
+            "rent",
+            "price",
+            "listing",
+        ]
+        is_query = any(k in text for k in keywords)
 
     logger.info("query_classifier_agent result: %s", is_query)
     return {"is_property_query": is_query}


### PR DESCRIPTION
## Summary
- add keyword-based fallback in query classifier to detect property-related messages when LLM is unavailable
- ensures property retrieval and card rendering still work without AWS credentials

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a68a4787883268600caf1e3e1b588