### PR TITLE
Expose property cards in LangGraph chat responses

### DIFF
--- a/backend/langgraph_app.py
+++ b/backend/langgraph_app.py
@@ -89,6 +89,8 @@ class GraphState(TypedDict, total=False):
     is_property_query: bool
     listings: List[Dict[str, Any]]
     answer: str
+    reply: str
+    properties: List[Dict[str, Any]]
 
 
 retriever = PropertyRetriever(

--- a/tests/test_property_cards_output.py
+++ b/tests/test_property_cards_output.py
@@ -1,0 +1,12 @@
+import asyncio
+import sys
+
+sys.path.append('backend')
+from langgraph_app import app_graph
+
+
+def test_chat_response_includes_property_fields():
+    result = asyncio.run(app_graph.ainvoke({'user_input': 'hello'}))
+    assert 'reply' in result
+    assert 'properties' in result
+    assert isinstance(result['properties'], list)


### PR DESCRIPTION
## Summary
- Ensure `LangGraph` workflow keeps `reply` and `properties` in state so chat responses can include property cards
- Add regression test verifying chat endpoint returns property list field

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b4314d0848326bb548db2855eb371