### PR TITLE
Display property details beneath messages and expand sourcing data

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -100,7 +100,8 @@ function router(){
       const marker=state.markers[p.id];
       if(marker){
         if(window.google?.maps){
-          state.infoWin.setContent(`<div>${p.address}<br/>${p.price}<br/><button id="addLead">Add to Leads</button></div>`);
+          const details=[p.beds?`${p.beds} bd`:'',p.baths?`${p.baths} ba`:'',p.year?`Built ${p.year}`:''].filter(Boolean).join(' | ');
+          state.infoWin.setContent(`<div>${p.address}<br/>${p.price}${details?`<br/>${details}`:''}<br/><button id="addLead">Add to Leads</button></div>`);
           state.infoWin.addListener('domready',()=>{
             const btn=document.getElementById('addLead');
             if(btn) btn.onclick=()=>{location.hash=`#/leads?prop=${p.id}`;};
@@ -168,7 +169,8 @@ function router(){
         const lat=Number(p.lat), lng=Number(p.lng);
         if(!isNaN(lat)&&!isNaN(lng)){
           const position=[lat,lng];
-          const marker=L.marker(position).addTo(state.gmap).bindPopup(`<div>${p.address}<br/>${p.price}<br/><button class='add-lead'>Add to Leads</button></div>`);
+          const details=[p.beds?`${p.beds} bd`:'',p.baths?`${p.baths} ba`:'',p.year?`Built ${p.year}`:''].filter(Boolean).join(' | ');
+          const marker=L.marker(position).addTo(state.gmap).bindPopup(`<div>${p.address}<br/>${p.price}${details?`<br/>${details}`:''}<br/><button class='add-lead'>Add to Leads</button></div>`);
           state.markers[p.id]=marker;
           bounds.extend(position);
           marker.on('click',()=>selectProperty(p.id));
@@ -268,6 +270,12 @@ function parseCSV(text){
     const price=obj[' List Price ']||obj['List Price']||'';
     const lat=parseFloat(obj['Latitude']);
     const lng=parseFloat(obj['Longitude']);
-    return {id,address,price,lat,lng};
+    const beds=obj['Bedrooms'];
+    const fullBaths=parseFloat(obj['Full Bathrooms'])||0;
+    const halfBaths=parseFloat(obj['Half Bathrooms'])||0;
+    const bathsVal=fullBaths+halfBaths*0.5;
+    const baths=bathsVal||'';
+    const year=obj['Year Built'];
+    return {id,address,price,lat,lng,beds,baths,year};
   });
 }

--- a/frontend/components/agent-chat.js
+++ b/frontend/components/agent-chat.js
@@ -66,7 +66,8 @@ export function createAgentChat() {
 
         const info = document.createElement('div');
         info.className = 'details';
-        info.innerHTML = `<strong>${p.address || ''}</strong><br/>${p.price || ''}<br/>${p.description || ''}`;
+        const details=[p.beds?`${p.beds} bd`:'',p.baths?`${p.baths} ba`:'',p.year?`Built ${p.year}`:''].filter(Boolean).join(' | ');
+        info.innerHTML = `<strong>${p.address || ''}</strong><br/>${p.price || ''}${details?`<br/>${details}`:''}<br/>${p.description || ''}`;
 
         if (p.id) {
           const btn = document.createElement('button');

--- a/frontend/components/datagrid.js
+++ b/frontend/components/datagrid.js
@@ -9,11 +9,11 @@ export function createDataGrid(props = [], onSelect) {
   setTimeout(() => render(), 800);
   function render() {
     el.innerHTML =
-      `<table class="data"><thead><tr><th>Address</th><th>Price</th></tr></thead><tbody>` +
+      `<table class="data"><thead><tr><th>Address</th><th>Price</th><th>Beds</th><th>Baths</th><th>Year</th></tr></thead><tbody>` +
       props
         .map(
           (p) =>
-            `<tr data-prop-id="${p.id}"><td>${p.address}</td><td>${p.price}</td></tr>`
+            `<tr data-prop-id="${p.id}"><td>${p.address}</td><td>${p.price}</td><td>${p.beds||''}</td><td>${p.baths||''}</td><td>${p.year||''}</td></tr>`
         )
         .join('') +
       `</tbody></table>`;

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -215,7 +215,7 @@ button:hover{
 .msg {
   margin-bottom:var(--gap);
   display:flex;
- 
+  flex-direction:column;
 }
 .msg span {
   padding:8px 12px;
@@ -225,12 +225,12 @@ button:hover{
   animation:slide-up 0.2s ease;
   backdrop-filter: blur(12px);
 }
-.msg.bot { justify-content:flex-start; }
+.msg.bot { align-items:flex-start; }
 .msg.bot span { background:var(--muted); color:var(--text); }
-.msg.user { justify-content:flex-end; }
+.msg.user { align-items:flex-end; }
 .msg.user span { background:var(--accent); color:white; }
 
-.prop-cards { margin-top:var(--gap); display:flex; flex-direction:column; gap:var(--gap); }
+.prop-cards { margin-top:var(--gap); display:flex; flex-direction:column; gap:var(--gap); max-width:80%; }
 .prop-card {
   display:flex;
   gap:var(--gap);


### PR DESCRIPTION
## Summary
- Stack property cards beneath chat responses and align messages with flexbox.
- Parse additional listing fields (beds, baths, year) and surface them in sourcing grid and map popups.
- Show extra listing info on chat property cards for richer context.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b487db15083269a3a891791b63413