### PR TITLE
Enhance property cards and sourcing details

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -100,7 +100,14 @@ function router(){
       const marker=state.markers[p.id];
       if(marker){
         if(window.google?.maps){
-          const details=[p.beds?`${p.beds} bd`:'',p.baths?`${p.baths} ba`:'',p.year?`Built ${p.year}`:''].filter(Boolean).join(' | ');
+          const details=[
+            p.beds?`${p.beds} bd`:'',
+            p.baths?`${p.baths} ba`:'',
+            p.year?`Built ${p.year}`:'',
+            p.status||'',
+            p.type||'',
+            p.saleOrRent||''
+          ].filter(Boolean).join(' | ');
           state.infoWin.setContent(`<div>${p.address}<br/>${p.price}${details?`<br/>${details}`:''}<br/><button id="addLead">Add to Leads</button></div>`);
           state.infoWin.addListener('domready',()=>{
             const btn=document.getElementById('addLead');
@@ -169,7 +176,14 @@ function router(){
         const lat=Number(p.lat), lng=Number(p.lng);
         if(!isNaN(lat)&&!isNaN(lng)){
           const position=[lat,lng];
-          const details=[p.beds?`${p.beds} bd`:'',p.baths?`${p.baths} ba`:'',p.year?`Built ${p.year}`:''].filter(Boolean).join(' | ');
+          const details=[
+            p.beds?`${p.beds} bd`:'',
+            p.baths?`${p.baths} ba`:'',
+            p.year?`Built ${p.year}`:'',
+            p.status||'',
+            p.type||'',
+            p.saleOrRent||''
+          ].filter(Boolean).join(' | ');
           const marker=L.marker(position).addTo(state.gmap).bindPopup(`<div>${p.address}<br/>${p.price}${details?`<br/>${details}`:''}<br/><button class='add-lead'>Add to Leads</button></div>`);
           state.markers[p.id]=marker;
           bounds.extend(position);
@@ -276,6 +290,9 @@ function parseCSV(text){
     const bathsVal=fullBaths+halfBaths*0.5;
     const baths=bathsVal||'';
     const year=obj['Year Built'];
-    return {id,address,price,lat,lng,beds,baths,year};
+    const status=obj['Listing Status'];
+    const saleOrRent=obj['Sale or Rent'];
+    const type=obj['Property Type']||obj['Property Subtype'];
+    return {id,address,price,lat,lng,beds,baths,year,status,saleOrRent,type};
   });
 }

--- a/frontend/components/datagrid.js
+++ b/frontend/components/datagrid.js
@@ -9,11 +9,11 @@ export function createDataGrid(props = [], onSelect) {
   setTimeout(() => render(), 800);
   function render() {
     el.innerHTML =
-      `<table class="data"><thead><tr><th>Address</th><th>Price</th><th>Beds</th><th>Baths</th><th>Year</th></tr></thead><tbody>` +
+      `<table class="data"><thead><tr><th>Address</th><th>Price</th><th>Beds</th><th>Baths</th><th>Year</th><th>Status</th><th>Type</th><th>Sale/Rent</th></tr></thead><tbody>` +
       props
         .map(
           (p) =>
-            `<tr data-prop-id="${p.id}"><td>${p.address}</td><td>${p.price}</td><td>${p.beds||''}</td><td>${p.baths||''}</td><td>${p.year||''}</td></tr>`
+            `<tr data-prop-id="${p.id}"><td>${p.address}</td><td>${p.price}</td><td>${p.beds||''}</td><td>${p.baths||''}</td><td>${p.year||''}</td><td>${p.status||''}</td><td>${p.type||''}</td><td>${p.saleOrRent||''}</td></tr>`
         )
         .join('') +
       `</tbody></table>`;

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -230,23 +230,35 @@ button:hover{
 .msg.user { align-items:flex-end; }
 .msg.user span { background:var(--accent); color:white; }
 
-.prop-cards { margin-top:var(--gap); display:flex; flex-direction:column; gap:var(--gap); max-width:80%; }
+.prop-cards {
+  margin-top:var(--gap);
+  display:flex;
+  flex-direction:row;
+  gap:var(--gap);
+  max-width:100%;
+  overflow-x:auto;
+  padding-bottom:var(--gap);
+}
 .prop-card {
   display:flex;
+  flex-direction:column;
   gap:var(--gap);
   background:var(--muted);
   padding:var(--gap);
   border-radius:var(--radius-sm);
   box-shadow:var(--shadow);
   align-items:flex-start;
+  flex:0 0 200px;
 }
 .prop-card img {
-  width:80px;
-  height:60px;
+  width:100%;
+  height:120px;
   object-fit:cover;
   border-radius:var(--radius-sm);
 }
-.prop-card .details { flex:1; }
+.prop-card .details {
+  flex:1;
+}
 .prop-card button { margin-top:var(--gap); }
 .prop-card:hover { background:var(--card); }
 


### PR DESCRIPTION
## Summary
- Restyle chat property cards into a horizontal, scrollable row for a cleaner layout
- Parse listing status, type, and sale/rent fields from the CSV and surface them in the sourcing data grid and map popups

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b4c127fa883269e1d2f211a021830