### PR TITLE
Use listings CSV for RAG server

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ fastapi
 uvicorn
 python-dotenv
 langgraph
+scikit-learn


### PR DESCRIPTION
## Summary
- Load property data for RAG server from CSV dataset via PropertyRetriever
- Add scikit-learn dependency for TF-IDF similarity index

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b6669870083268d32fa989fe4eb25