### PR TITLE
feat: add forms for properties and leads

### DIFF
--- a/frontend/components/kanban.js
+++ b/frontend/components/kanban.js
@@ -11,9 +11,7 @@ export function createKanban(leads=[],callbacks={}) {
   const addBtn=document.createElement('button');
   addBtn.textContent='Add Lead';
   addBtn.addEventListener('click',()=>{
-    const name=prompt('Lead name?');
-    const property=prompt('Interested property?');
-    if(name){ const id=Date.now(); if(onAdd) onAdd({id,name,stage:'New',property}); }
+    if(onAdd) onAdd();
   });
   controls.appendChild(addBtn);
   board.appendChild(controls);
@@ -31,7 +29,7 @@ export function createKanban(leads=[],callbacks={}) {
       const card=document.getElementById(id);
       col.appendChild(card);
       showToast(`Moved ${card.dataset.name} to ${s}`);
-      if(onEdit){ const leadId=parseInt(id.replace('lead-','')); onEdit({id:leadId,name:card.dataset.name,stage:s,property:card.dataset.property}); }
+      if(onEdit){ const leadId=parseInt(id.replace('lead-','')); onEdit({id:leadId,name:card.dataset.name,stage:s,property:card.dataset.property,email:card.dataset.email,phone:card.dataset.phone}); }
     });
     board.appendChild(col);
     columns[s]=col;
@@ -46,6 +44,8 @@ export function createKanban(leads=[],callbacks={}) {
       card.id='lead-'+l.id;
       card.dataset.name=l.name;
       card.dataset.property=l.property||'';
+      card.dataset.email=l.email||'';
+      card.dataset.phone=l.phone||'';
       card.innerHTML=`<strong>${l.name}</strong>${l.property?`<br/><small>${l.property}</small>`:''}`;
       card.addEventListener('dragstart',e=>e.dataTransfer.setData('id',card.id));
       card.addEventListener('dblclick',()=>{
@@ -53,7 +53,9 @@ export function createKanban(leads=[],callbacks={}) {
         if(!name) return;
         const stage=prompt('Stage',l.stage)||l.stage;
         const property=prompt('Property',l.property||'')||l.property||'';
-        if(onEdit){ onEdit({id:l.id,name,stage:stages.includes(stage)?stage:l.stage,property}); }
+        const email=prompt('Email',l.email||'')||l.email||'';
+        const phone=prompt('Phone',l.phone||'')||l.phone||'';
+        if(onEdit){ onEdit({id:l.id,name,stage:stages.includes(stage)?stage:l.stage,property,email,phone}); }
       });
       columns[l.stage].appendChild(card);
     });

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -147,6 +147,29 @@ button:hover{
   background-color: rgb(255, 255, 255,0.6);
   border-color:var(--accent);
 }
+
+/* Forms */
+.property-form, .lead-form {
+  display:flex;
+  flex-direction:column;
+  gap:var(--gap);
+  max-width:320px;
+  margin:20px auto;
+  background:var(--card);
+  padding:var(--gap);
+  border-radius:var(--radius-lg);
+  box-shadow:var(--shadow);
+}
+.property-form label, .lead-form label {
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
+.form-actions {
+  display:flex;
+  gap:var(--gap);
+  justify-content:flex-end;
+}
 /* Views */
 .sourcing-view { display:flex; flex-direction:column; height:100%; }
 #map { min-height: 380px; width: 100%; border-radius: 12px; overflow: hidden; margin-right:0; margin-bottom:var(--gap); }


### PR DESCRIPTION
## Summary
- replace prompt-based property creation with structured form
- collect lead details with dedicated form and hook into kanban board
- style new property and lead forms for better layout

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b9ce69d8c8326bf50e0e798324044