### PR TITLE
Add listing number fields and improve modal forms

### DIFF
--- a/frontend/components/kanban.js
+++ b/frontend/components/kanban.js
@@ -29,7 +29,7 @@ export function createKanban(leads=[],callbacks={}) {
       const card=document.getElementById(id);
       col.appendChild(card);
       showToast(`Moved ${card.dataset.name} to ${s}`);
-      if(onEdit){ const leadId=parseInt(id.replace('lead-','')); onEdit({id:leadId,name:card.dataset.name,stage:s,property:card.dataset.property,email:card.dataset.email,phone:card.dataset.phone}); }
+      if(onEdit){ const leadId=parseInt(id.replace('lead-','')); onEdit({id:leadId,name:card.dataset.name,stage:s,property:card.dataset.property,email:card.dataset.email,phone:card.dataset.phone,listingNumber:card.dataset.listing}); }
     });
     board.appendChild(col);
     columns[s]=col;
@@ -46,7 +46,8 @@ export function createKanban(leads=[],callbacks={}) {
       card.dataset.property=l.property||'';
       card.dataset.email=l.email||'';
       card.dataset.phone=l.phone||'';
-      card.innerHTML=`<strong>${l.name}</strong>${l.property?`<br/><small>${l.property}</small>`:''}`;
+      card.dataset.listing=l.listingNumber||'';
+      card.innerHTML=`<strong>${l.name}</strong>${l.property?`<br/><small>${l.property}</small>`:''}${l.listingNumber?`<br/><small>${l.listingNumber}</small>`:''}`;
       card.addEventListener('dragstart',e=>e.dataTransfer.setData('id',card.id));
       card.addEventListener('dblclick',()=>{
         const name=prompt('Lead name',l.name);
@@ -55,7 +56,8 @@ export function createKanban(leads=[],callbacks={}) {
         const property=prompt('Property',l.property||'')||l.property||'';
         const email=prompt('Email',l.email||'')||l.email||'';
         const phone=prompt('Phone',l.phone||'')||l.phone||'';
-        if(onEdit){ onEdit({id:l.id,name,stage:stages.includes(stage)?stage:l.stage,property,email,phone}); }
+        const listing=prompt('Listing Number',l.listingNumber||'')||l.listingNumber||'';
+        if(onEdit){ onEdit({id:l.id,name,stage:stages.includes(stage)?stage:l.stage,property,email,phone,listingNumber:listing}); }
       });
       columns[l.stage].appendChild(card);
     });

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -163,9 +163,9 @@ button:hover{
   display:flex;
   flex-direction:column;
   gap:var(--gap);
-  max-width:320px;
+  max-width:400px;
   margin:0;
-  background:var(--card);
+  background:#fff;
   padding:var(--gap);
   border-radius:var(--radius-lg);
   box-shadow:var(--shadow);


### PR DESCRIPTION
## Summary
- Widen modal forms and switch to white background
- Collect listing numbers and city info for properties and leads
- Show listing numbers on lead kanban cards

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ba4b607e08326b893a3a2d85e6e10