### PR TITLE
Make forms scrollable and capture more lead details

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -359,6 +359,8 @@ function router(){
             <label>Name:<input name='name' required/></label>
             <label>Email:<input name='email' type='email'/></label>
             <label>Phone:<input name='phone'/></label>
+            <label>Address:<input name='address'/></label>
+            <label>Notes:<textarea name='notes'></textarea></label>
             <div class='form-actions'>
               <button type='submit'>Save</button>
               <button type='button' id='cancelLead'>Cancel</button>
@@ -371,9 +373,11 @@ function router(){
             const name=form.name.value.trim();
             const email=form.email.value.trim();
             const phone=form.phone.value.trim();
+            const address=form.address.value.trim();
+            const notes=form.notes.value.trim();
             if(!name||!listing) return;
             state.data.leads=state.data.leads||[];
-            state.data.leads.push({id:Date.now(),listingNumber:listing,name,email,phone,stage:'New',property:p?fullAddress:''});
+            state.data.leads.push({id:Date.now(),listingNumber:listing,name,email,phone,address,notes,stage:'New',property:p?fullAddress:''});
             close();
           });
         form.querySelector('#cancelLead').addEventListener('click',close);

--- a/frontend/components/kanban.js
+++ b/frontend/components/kanban.js
@@ -29,7 +29,7 @@ export function createKanban(leads=[],callbacks={}) {
       const card=document.getElementById(id);
       col.appendChild(card);
       showToast(`Moved ${card.dataset.name} to ${s}`);
-      if(onEdit){ const leadId=parseInt(id.replace('lead-','')); onEdit({id:leadId,name:card.dataset.name,stage:s,property:card.dataset.property,email:card.dataset.email,phone:card.dataset.phone,listingNumber:card.dataset.listing}); }
+      if(onEdit){ const leadId=parseInt(id.replace('lead-','')); onEdit({id:leadId,name:card.dataset.name,stage:s,property:card.dataset.property,email:card.dataset.email,phone:card.dataset.phone,listingNumber:card.dataset.listing,address:card.dataset.address,notes:card.dataset.notes}); }
     });
     board.appendChild(col);
     columns[s]=col;
@@ -47,7 +47,9 @@ export function createKanban(leads=[],callbacks={}) {
       card.dataset.email=l.email||'';
       card.dataset.phone=l.phone||'';
       card.dataset.listing=l.listingNumber||'';
-      card.innerHTML=`<strong>${l.name}</strong>${l.property?`<br/><small>${l.property}</small>`:''}${l.listingNumber?`<br/><small>${l.listingNumber}</small>`:''}`;
+      card.dataset.address=l.address||'';
+      card.dataset.notes=l.notes||'';
+      card.innerHTML=`<strong>${l.name}</strong>${l.property?`<br/><small>${l.property}</small>`:''}${l.listingNumber?`<br/><small>${l.listingNumber}</small>`:''}${l.address?`<br/><small>${l.address}</small>`:''}`;
       card.addEventListener('dragstart',e=>e.dataTransfer.setData('id',card.id));
       card.addEventListener('dblclick',()=>{
         const name=prompt('Lead name',l.name);
@@ -57,7 +59,9 @@ export function createKanban(leads=[],callbacks={}) {
         const email=prompt('Email',l.email||'')||l.email||'';
         const phone=prompt('Phone',l.phone||'')||l.phone||'';
         const listing=prompt('Listing Number',l.listingNumber||'')||l.listingNumber||'';
-        if(onEdit){ onEdit({id:l.id,name,stage:stages.includes(stage)?stage:l.stage,property,email,phone,listingNumber:listing}); }
+        const address=prompt('Address',l.address||'')||l.address||'';
+        const notes=prompt('Notes',l.notes||'')||l.notes||'';
+        if(onEdit){ onEdit({id:l.id,name,stage:stages.includes(stage)?stage:l.stage,property,email,phone,listingNumber:listing,address,notes}); }
       });
       columns[l.stage].appendChild(card);
     });

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -165,6 +165,8 @@ button:hover{
   gap:var(--gap);
   width:50vw;
   max-width:none;
+  max-height:80vh;
+  overflow-y:auto;
   margin:0;
   background:#fff;
   padding:var(--gap);
@@ -177,6 +179,8 @@ button:hover{
   flex-direction:column;
   gap:var(--gap);
   max-width:400px;
+  max-height:80vh;
+  overflow-y:auto;
   margin:0;
   background:#fff;
   padding:var(--gap);


### PR DESCRIPTION
## Summary
- Limit property and lead forms to 80% viewport height and allow scrolling
- Add address and notes fields to lead entry workflow
- Store and edit additional lead details in kanban board

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689bad5ab0708326a2107bd36cf5cf6a