### PR TITLE
Expand lead form width to improve usability

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -178,7 +178,8 @@ button:hover{
   display:flex;
   flex-direction:column;
   gap:var(--gap);
-  max-width:400px;
+  width:50%;
+  max-width:none;
   max-height:80vh;
   overflow-y:auto;
   margin:0;


### PR DESCRIPTION
## Summary
- Widen lead entry form to 50% of viewport for better visibility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bb356891c832699d127e16c29ef75