### PR TITLE
Add modal editing for leads

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -347,7 +347,46 @@ function router(){
       const params=new URLSearchParams(query||'');
       const propId=params.get('prop');
       const isNew=params.has('new');
-        if(propId || isNew){
+      const editId=params.get('edit');
+        if(propId || isNew || editId){
+          if(editId){
+            const lead=(state.data.leads||[]).find(x=>String(x.id)===String(editId));
+            if(lead){
+              const overlay=document.createElement('div');
+              overlay.className='modal';
+              const form=document.createElement('form');
+              form.className='lead-form';
+              form.innerHTML=`<h2>Edit Lead${lead.property?` for ${lead.property}`:''}</h2>
+                <label>Listing Number:<input name='listing' value='${lead.listingNumber||''}' required/></label>
+                <label>Name:<input name='name' value='${lead.name||''}' required/></label>
+                <label>Email:<input name='email' type='email' value='${lead.email||''}'/></label>
+                <label>Phone:<input name='phone' value='${lead.phone||''}'/></label>
+                <label>Address:<input name='address' value='${lead.address||''}'/></label>
+                <label>Notes:<textarea name='notes'>${lead.notes||''}</textarea></label>
+                <div class='form-actions'>
+                  <button type='submit'>Save</button>
+                  <button type='button' id='cancelLead'>Cancel</button>
+                </div>`;
+              const close=()=>{ overlay.remove(); location.hash='#/leads'; };
+              overlay.addEventListener('click',e=>{ if(e.target===overlay) close(); });
+              form.addEventListener('submit',e=>{
+                e.preventDefault();
+                const listing=form.listing.value.trim();
+                const name=form.name.value.trim();
+                const email=form.email.value.trim();
+                const phone=form.phone.value.trim();
+                const address=form.address.value.trim();
+                const notes=form.notes.value.trim();
+                if(!name||!listing) return;
+                const i=state.data.leads.findIndex(x=>x.id===lead.id);
+                if(i>-1) state.data.leads[i]={...state.data.leads[i],listingNumber:listing,name,email,phone,address,notes};
+                close();
+              });
+              form.querySelector('#cancelLead').addEventListener('click',close);
+              overlay.appendChild(form);
+              document.body.appendChild(overlay);
+            }
+          } else {
           const p=propId?(state.data.properties||[]).find(x=>String(x.id)===String(propId)):null;
           const overlay=document.createElement('div');
           overlay.className='modal';
@@ -383,7 +422,8 @@ function router(){
         form.querySelector('#cancelLead').addEventListener('click',close);
         overlay.appendChild(form);
         document.body.appendChild(overlay);
-      }
+          }
+        }
   } else if(route.startsWith('#/outreach')){
     topbarAPI.setActive('#/outreach');
     main.appendChild(createOutreach());

--- a/frontend/components/kanban.js
+++ b/frontend/components/kanban.js
@@ -52,16 +52,8 @@ export function createKanban(leads=[],callbacks={}) {
       card.innerHTML=`<strong>${l.name}</strong>${l.property?`<br/><small>${l.property}</small>`:''}${l.listingNumber?`<br/><small>${l.listingNumber}</small>`:''}${l.address?`<br/><small>${l.address}</small>`:''}`;
       card.addEventListener('dragstart',e=>e.dataTransfer.setData('id',card.id));
       card.addEventListener('dblclick',()=>{
-        const name=prompt('Lead name',l.name);
-        if(!name) return;
-        const stage=prompt('Stage',l.stage)||l.stage;
-        const property=prompt('Property',l.property||'')||l.property||'';
-        const email=prompt('Email',l.email||'')||l.email||'';
-        const phone=prompt('Phone',l.phone||'')||l.phone||'';
-        const listing=prompt('Listing Number',l.listingNumber||'')||l.listingNumber||'';
-        const address=prompt('Address',l.address||'')||l.address||'';
-        const notes=prompt('Notes',l.notes||'')||l.notes||'';
-        if(onEdit){ onEdit({id:l.id,name,stage:stages.includes(stage)?stage:l.stage,property,email,phone,listingNumber:listing,address,notes}); }
+        // Route to lead edit form when double-clicked
+        location.hash = `#/leads?edit=${l.id}`;
       });
       columns[l.stage].appendChild(card);
     });


### PR DESCRIPTION
## Summary
- Allow double-clicking a lead card to open an edit form
- Add modal form to edit lead details with prepopulated fields and save/cancel actions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bb7c838348326ad323dcefdae99d6