### PR TITLE
Add styled sign-in and sign-up pages with logout flow

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -10,7 +10,7 @@ This directory contains a minimal browser client that displays a floating chat w
    cd frontend
    python -m http.server 8001
    ```
-3. Open [http://localhost:8001](http://localhost:8001) in a browser. Click the blue chat bubble in the bottom-right corner to open the widget and ask about properties.
+3. Open [http://localhost:8001/signin.html](http://localhost:8001/signin.html) to create an account or sign in. After signing up you will be returned to the sign-in page. Once logged in you will be redirected to the main app where you can click the blue chat bubble in the bottom-right corner to open the widget and ask about properties. Use the "Logout" button in the top bar to sign out at any time.
 
    The app falls back to [OpenStreetMap](https://www.openstreetmap.org/) via Leaflet when no Google Maps key is provided. To use Google Maps instead, copy `config.sample.js` to `config.js` and replace `YOUR_API_KEY_HERE` with a valid API key.
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -48,18 +48,7 @@ function startApp(){
   });
 }
 
-const loginForm=document.getElementById('login-form');
-if(loginForm){
-  loginForm.addEventListener('submit',e=>{
-    e.preventDefault();
-    loginForm.style.display='none';
-    const app=document.getElementById('app');
-    if(app) app.style.display='';
-    startApp();
-  });
-}else{
-  startApp();
-}
+startApp();
 
 function init(){
   topbarAPI=initTopbar();

--- a/frontend/auth.css
+++ b/frontend/auth.css
@@ -1,0 +1,57 @@
+body {
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Inter', sans-serif;
+  background: linear-gradient(135deg, #3b82f6, #9333ea);
+}
+
+.auth-card {
+  background: rgba(255, 255, 255, 0.9);
+  padding: 40px;
+  border-radius: 16px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
+  width: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.auth-card h2 {
+  margin: 0 0 8px;
+  text-align: center;
+  color: #111;
+}
+
+.auth-card input {
+  padding: 10px;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+}
+
+.auth-card button {
+  padding: 10px;
+  border: none;
+  border-radius: 8px;
+  background: #3b82f6;
+  color: #fff;
+  cursor: pointer;
+  font-size: 16px;
+}
+
+.auth-card button:hover {
+  background: #2563eb;
+}
+
+.auth-switch {
+  text-align: center;
+  color: #111;
+  font-size: 14px;
+}
+
+.auth-switch a {
+  color: #2563eb;
+  text-decoration: none;
+}

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -1,0 +1,34 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const signinForm = document.getElementById('signin-form');
+  const signupForm = document.getElementById('signup-form');
+  const isLoggedIn = localStorage.getItem('loggedIn') === 'true';
+
+  if (isLoggedIn && (signinForm || signupForm)) {
+    window.location.href = 'index.html';
+    return;
+  }
+
+  if (signinForm) {
+    signinForm.addEventListener('submit', e => {
+      e.preventDefault();
+      const stored = JSON.parse(localStorage.getItem('user') || '{}');
+      const { username, password } = signinForm;
+      if (username.value === stored.username && password.value === stored.password) {
+        localStorage.setItem('loggedIn', 'true');
+        window.location.href = 'index.html';
+      } else {
+        alert('Invalid credentials');
+      }
+    });
+  }
+
+  if (signupForm) {
+    signupForm.addEventListener('submit', e => {
+      e.preventDefault();
+      const { username, password } = signupForm;
+      localStorage.setItem('user', JSON.stringify({ username: username.value, password: password.value }));
+      localStorage.removeItem('loggedIn');
+      window.location.href = 'signin.html';
+    });
+  }
+});

--- a/frontend/components/topbar.js
+++ b/frontend/components/topbar.js
@@ -23,9 +23,17 @@ export function initTopbar() {
         <option value="rent">For Rent</option>
       </select>
       <div class="avatar">⚫</div>
+      <button id="logout-btn">Logout</button>
     </div>
   `;
   bar.querySelectorAll('.tab').forEach(t=>t.addEventListener('click',()=>location.hash=t.dataset.route));
+  const logout = bar.querySelector('#logout-btn');
+  if (logout) {
+    logout.addEventListener('click', () => {
+      localStorage.removeItem('loggedIn');
+      window.location.href = 'signin.html';
+    });
+  }
   return { setActive: (route)=> {
     bar.querySelectorAll('.tab').forEach(t=>{
       if(t.dataset.route===route) t.classList.add('active');

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,11 +11,6 @@
 </head>
 <body>
   <div id="bg"></div>
-  <form id="login-form" class="login-form">
-    <input name="username" placeholder="username" required>
-    <input name="password" type="password" placeholder="password" required>
-    <button type="submit">Login</button>
-  </form>
   <div id="app" style="display:none">
     <div id="topbar"></div>
     <div id="layout">
@@ -26,6 +21,13 @@
     <div id="command-palette" class="hidden"></div>
     <div id="toast-container"></div>
   </div>
+  <script>
+    if(localStorage.getItem('loggedIn') !== 'true'){
+      window.location.href='signin.html';
+    }else{
+      document.getElementById('app').style.display='';
+    }
+  </script>
   <script src="config.js"></script>
   <script type="module" src="app.js"></script>
 </body>

--- a/frontend/signin.html
+++ b/frontend/signin.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sign In - Cascade AI</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="auth.css">
+</head>
+<body>
+  <form id="signin-form" class="auth-card">
+    <h2>Sign In</h2>
+    <input name="username" placeholder="Username" required>
+    <input name="password" type="password" placeholder="Password" required>
+    <button type="submit">Sign In</button>
+    <div class="auth-switch">Don't have an account? <a href="signup.html">Sign up</a></div>
+  </form>
+  <script src="auth.js"></script>
+</body>
+</html>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sign Up - Cascade AI</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="auth.css">
+</head>
+<body>
+  <form id="signup-form" class="auth-card">
+    <h2>Create Account</h2>
+    <input name="username" placeholder="Username" required>
+    <input name="password" type="password" placeholder="Password" required>
+    <button type="submit">Sign Up</button>
+    <div class="auth-switch">Already have an account? <a href="signin.html">Sign in</a></div>
+  </form>
+  <script src="auth.js"></script>
+</body>
+</html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -60,6 +60,7 @@ body {
 #topbar .tabs {display:flex; gap:var(--gap);}
 #topbar .right {display:flex; align-items:center; gap:var(--gap);}
 #topbar input, #topbar select {height:36px;}
+#topbar button {height:36px;}
 #topbar .avatar {width:32px;height:32px;border-radius:50%;background:var(--muted);}
 #topbar .logo {font-weight:bold; cursor:pointer; transition:transform 0.3s, text-shadow 0.3s; color: aliceblue; font-size: large;}
 #topbar .logo:hover {transform:scale(1.1); text-shadow:0 0 12px var(--accent);}


### PR DESCRIPTION
## Summary
- Redirect new sign-ups back to sign-in so the app only loads for logged-in users
- Add logout button in the top bar that clears the session and returns to sign-in
- Ensure index page checks explicit login flag before showing the app

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cbb0faa908326a9395cc0cb73699a