### PR TITLE
Add logout support and redirect after signup

### DIFF
--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -20,8 +20,8 @@ document.addEventListener('DOMContentLoaded', () => {
       e.preventDefault();
       const { username, password } = signupForm;
       localStorage.setItem('user', JSON.stringify({ username: username.value, password: password.value }));
-      localStorage.setItem('loggedIn', 'true');
-      window.location.href = 'index.html';
+      localStorage.removeItem('loggedIn');
+      window.location.href = 'signin.html';
     });
   }
 });

--- a/frontend/components/topbar.js
+++ b/frontend/components/topbar.js
@@ -22,10 +22,18 @@ export function initTopbar() {
         <option value="sale">For Sale</option>
         <option value="rent">For Rent</option>
       </select>
+      <button id="logout-btn">Logout</button>
       <div class="avatar">⚫</div>
     </div>
   `;
   bar.querySelectorAll('.tab').forEach(t=>t.addEventListener('click',()=>location.hash=t.dataset.route));
+  const logoutBtn = bar.querySelector('#logout-btn');
+  if (logoutBtn) {
+    logoutBtn.addEventListener('click', () => {
+      localStorage.removeItem('loggedIn');
+      window.location.href = 'signin.html';
+    });
+  }
   return { setActive: (route)=> {
     bar.querySelectorAll('.tab').forEach(t=>{
       if(t.dataset.route===route) t.classList.add('active');

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -60,6 +60,8 @@ body {
 #topbar .tabs {display:flex; gap:var(--gap);}
 #topbar .right {display:flex; align-items:center; gap:var(--gap);}
 #topbar input, #topbar select {height:36px;}
+#topbar button {height:36px; background:var(--accent); color:white; border:none; cursor:pointer; border-radius:var(--radius-sm);}
+#topbar button:hover {filter:brightness(0.9);}
 #topbar .avatar {width:32px;height:32px;border-radius:50%;background:var(--muted);}
 #topbar .logo {font-weight:bold; cursor:pointer; transition:transform 0.3s, text-shadow 0.3s; color: aliceblue; font-size: large;}
 #topbar .logo:hover {transform:scale(1.1); text-shadow:0 0 12px var(--accent);}


### PR DESCRIPTION
## Summary
- Add logout button in the top bar that clears login state and returns to sign in
- Redirect newly registered users to the sign-in page instead of auto-login
- Style top bar logout button for consistency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689cc0e5f3488326a789eacb06ec307a