### PR TITLE
Allow configuring API base URL for frontend

### DIFF
--- a/frontend/components/agent-chat.js
+++ b/frontend/components/agent-chat.js
@@ -20,6 +20,8 @@ export function createAgentChat() {
   // Render any previous chat history
   history.forEach(m => renderMessage(m));
 
+  const API_BASE = window.API_BASE_URL || 'http://localhost:8000';
+
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
     const text = input.value.trim();
@@ -27,7 +29,7 @@ export function createAgentChat() {
     addMessage('user', text);
     input.value = '';
     try {
-      const resp = await fetch('http://localhost:8000/chat', {
+      const resp = await fetch(`${API_BASE}/chat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text })

--- a/frontend/components/appointment.js
+++ b/frontend/components/appointment.js
@@ -28,10 +28,12 @@ export async function openAppointmentForm(property){
   // Default daily time slots
   const defaultTimes = ['9:00 AM', '11:00 AM', '1:00 PM'];
 
+  const API_BASE = window.API_BASE_URL || 'http://localhost:8000';
+
   // Fetch booked events from backend
   const booked = {};
   try {
-    const res = await fetch('/appointments');
+    const res = await fetch(`${API_BASE}/appointments`);
     const data = await res.json();
     data.forEach(ev => {
       const d = new Date(ev.start);
@@ -127,7 +129,7 @@ export async function openAppointmentForm(property){
     }
     const { name, phone, email, date, time } = form;
     try {
-      const res = await fetch('/appointments', {
+      const res = await fetch(`${API_BASE}/appointments`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/frontend/config.sample.js
+++ b/frontend/config.sample.js
@@ -1,1 +1,5 @@
 window.GOOGLE_MAPS_API_KEY = 'YOUR_API_KEY_HERE';
+
+// Base URL for backend API requests. Adjust the port if your FastAPI server
+// runs elsewhere.
+window.API_BASE_URL = 'http://localhost:8000';


### PR DESCRIPTION
## Summary
- Add `API_BASE_URL` setting to frontend config for backend API calls
- Use configurable base URL for chat and appointments requests to avoid hitting static server

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689d01e58df08326925f7e95b08b4eac