### PR TITLE
fix: expose appointment routes and add tests

### DIFF
--- a/backend/langgraph_app.py
+++ b/backend/langgraph_app.py
@@ -15,8 +15,8 @@ from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException
 from langgraph.graph import StateGraph, END
 from pydantic import BaseModel
-from property_chatbot import PropertyRetriever
-from appointments import GoogleCalendarClient
+from .property_chatbot import PropertyRetriever
+from .appointments import GoogleCalendarClient
 
 load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 

--- a/backend/web_app.py
+++ b/backend/web_app.py
@@ -11,9 +11,9 @@ from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 
-from langgraph_app import app_graph
-from property_chatbot import SonicClient
-from appointments import GoogleCalendarClient
+from .langgraph_app import app_graph
+from .property_chatbot import SonicClient
+from .appointments import GoogleCalendarClient
 
 logging.basicConfig(level=logging.INFO)
 

--- a/tests/test_appointment_endpoints.py
+++ b/tests/test_appointment_endpoints.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+from fastapi.testclient import TestClient
+
+# Ensure repository root on path so ``backend`` package is importable
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from backend.langgraph_app import app
+
+
+def test_appointment_routes():
+    client = TestClient(app)
+    # Should return an empty list when no events have been created
+    resp = client.get("/appointments")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+    # Booking an appointment should succeed and return an event id
+    payload = {
+        "name": "Alice",
+        "phone": "123-456-7890",
+        "email": "alice@example.com",
+        "date": "2024-01-01",
+        "time": "9:00 AM",
+    }
+    resp = client.post("/appointments", json=payload)
+    assert resp.status_code == 200
+    assert "event" in resp.json()

--- a/tests/test_property_cards_output.py
+++ b/tests/test_property_cards_output.py
@@ -1,8 +1,10 @@
 import asyncio
+import os
 import sys
 
-sys.path.append('backend')
-from langgraph_app import app_graph
+# Ensure repository root on path so the ``backend`` package can be imported
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from backend.langgraph_app import app_graph
 
 
 def test_chat_response_includes_property_fields():


### PR DESCRIPTION
## Summary
- use package-relative imports so backend app exposes appointment routes when run from project root
- cover appointment booking and listing endpoints with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dfcfa3be883268635d59f77b6427b