### PR TITLE
Add appointment API router

### DIFF
--- a/backend/langgraph_app.py
+++ b/backend/langgraph_app.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, TypedDict
 from urllib.parse import unquote
@@ -12,11 +11,11 @@ from urllib.parse import unquote
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError
 from dotenv import load_dotenv
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI
 from langgraph.graph import StateGraph, END
 from pydantic import BaseModel
 from .property_chatbot import PropertyRetriever
-from .appointments import GoogleCalendarClient
+from .appointments import router as appointments_router
 
 load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 
@@ -99,7 +98,6 @@ retriever = PropertyRetriever(
     Path(__file__).resolve().parents[1] / "frontend" / "data" / "listings.csv"
 )
 llm_client = LLMClient()
-_calendar = GoogleCalendarClient()
 
 
 async def query_classifier_agent(state: GraphState) -> GraphState:
@@ -197,16 +195,6 @@ class ChatRequest(BaseModel):
     message: str
 
 
-class AppointmentRequest(BaseModel):
-    """Payload for booking a calendar slot."""
-
-    name: str
-    phone: str
-    email: str
-    date: str  # YYYY-MM-DD
-    time: str  # e.g. "9:00 AM"
-
-
 @app.post("/chat")
 async def chat(req: ChatRequest) -> Dict[str, Any]:
     logger.info("/chat request: %s", req.message)
@@ -216,30 +204,5 @@ async def chat(req: ChatRequest) -> Dict[str, Any]:
     return result
 
 
-@app.get("/appointments")
-async def list_appointments() -> List[Dict[str, Any]]:
-    """Return upcoming appointments from the realtor's calendar."""
-
-    return _calendar.list_events()
-
-
-@app.post("/appointments")
-async def book_appointment(payload: AppointmentRequest) -> Dict[str, Any]:
-    """Book a new appointment on the realtor's calendar."""
-
-    try:
-        dt = datetime.strptime(
-            f"{payload.date} {payload.time}", "%Y-%m-%d %I:%M %p"
-        )
-    except ValueError:
-        raise HTTPException(status_code=400, detail="invalid date or time format")
-
-    end = dt + timedelta(hours=1)
-    description = f"Phone: {payload.phone}\nEmail: {payload.email}"
-    summary = f"Appointment with {payload.name}"
-    try:
-        event = _calendar.create_event(summary, dt, end, description)
-    except RuntimeError as exc:
-        raise HTTPException(status_code=500, detail=str(exc))
-    return {"event": event}
+app.include_router(appointments_router)
 

--- a/backend/web_app.py
+++ b/backend/web_app.py
@@ -2,18 +2,15 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime, timedelta
-from typing import List
 
 from fastapi import FastAPI, UploadFile, File, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
-from pydantic import BaseModel
 
 from .langgraph_app import app_graph
 from .property_chatbot import SonicClient
-from .appointments import GoogleCalendarClient
+from .appointments import router as appointments_router
 
 logging.basicConfig(level=logging.INFO)
 
@@ -31,17 +28,7 @@ templates = Jinja2Templates(directory="templates")
 
 # Instantiate shared clients
 _sonic = SonicClient()
-_calendar = GoogleCalendarClient()
-
-
-class AppointmentRequest(BaseModel):
-    """Payload for booking a calendar slot."""
-
-    name: str
-    phone: str
-    email: str
-    date: str  # YYYY-MM-DD
-    time: str  # e.g. "9:00 AM"
+app.include_router(appointments_router)
 
 
 @app.get("/", response_class=HTMLResponse)
@@ -90,29 +77,3 @@ async def voice(file: UploadFile = File(...)):
     transcript = await asyncio.to_thread(_sonic.transcribe, audio_bytes)
     result = await app_graph.ainvoke({"user_input": transcript})
     return {**result, "transcript": transcript}
-
-
-@app.get("/appointments")
-async def list_appointments():
-    """Return upcoming appointments from the realtor's calendar."""
-    return _calendar.list_events()
-
-
-@app.post("/appointments")
-async def book_appointment(payload: AppointmentRequest):
-    """Book a new appointment on the realtor's Google Calendar."""
-    try:
-        dt = datetime.strptime(
-            f"{payload.date} {payload.time}", "%Y-%m-%d %I:%M %p"
-        )
-    except ValueError:
-        raise HTTPException(status_code=400, detail="invalid date or time format")
-
-    end = dt + timedelta(hours=1)
-    description = f"Phone: {payload.phone}\nEmail: {payload.email}"
-    summary = f"Appointment with {payload.name}"
-    try:
-        event = _calendar.create_event(summary, dt, end, description)
-    except RuntimeError as exc:  # calendar not configured
-        raise HTTPException(status_code=500, detail=str(exc))
-    return {"event": event}


### PR DESCRIPTION
## Summary
- add standalone appointment API router with GET and POST endpoints
- wire appointment router into main and web apps to expose `/appointments`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e03eafa588326a2dca5fb8665d30c