### PR TITLE
feat: add LLM-based SQL query generation

### DIFF
--- a/backend/agents/sql.py
+++ b/backend/agents/sql.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Dict, List
+import json
 import logging
+from urllib.parse import unquote
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError, NoCredentialsError
 
 from .base import Agent
 try:  # pragma: no cover - allow use as package or script
@@ -17,27 +22,88 @@ logger = logging.getLogger(__name__)
 class SQLQueryGeneratorAgent(Agent):
     """Generate a SQL query based on a natural language request."""
 
-    def __init__(self, limit: int = 5, registry=None) -> None:
+    def __init__(
+        self,
+        limit: int = 5,
+        registry=None,
+        model_id: str = "amazon.nova-lite-v1:0",
+        region: str = "us-east-1",
+    ) -> None:
         super().__init__("SQLQueryGeneratorAgent", registry)
         self.limit = limit
+        # Attempt to create a Bedrock client for LLM-powered SQL generation.
+        # If client creation fails we fall back to keyword search.
+        try:
+            self.client = boto3.client("bedrock-runtime", region_name=region)
+            self.model_id = unquote(model_id)
+            self.use_llm = True
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Falling back to heuristic SQL generation: %s", exc)
+            self.client = None
+            self.model_id = ""
+            self.use_llm = False
 
     async def handle(self, query: str, **_: Any) -> Dict[str, Any]:
-        words = [w.lower() for w in query.split() if w]
-        if words:
-            conditions = " OR ".join(
-                [
-                    "LOWER(address) LIKE '%{w}%' OR LOWER(location) LIKE '%{w}%' OR LOWER(description) LIKE '%{w}%'".format(
-                        w=w
-                    )
-                    for w in words
-                ]
+        sql_query = ""
+        if self.use_llm:
+            prompt = (
+                "You are an assistant that writes SQLite SQL queries for a table "
+                "'properties' with columns id, address, location, price, "
+                "description, image. "
+                f"Generate a SQL query that answers the user's request: {query}. "
+                f"Limit the results to {self.limit} rows. "
+                "Return only the SQL query."
             )
-        else:
-            conditions = "1=1"
-        sql_query = (
-            "SELECT id, address, location, price, description, image FROM properties "
-            f"WHERE {conditions} LIMIT {self.limit}"
-        )
+            body = json.dumps(
+                {
+                    "messages": [{"role": "user", "content": [{"text": prompt}]}],
+                    "inferenceConfig": {"maxTokens": 256, "temperature": 0},
+                }
+            )
+            try:
+                resp = self.client.invoke_model(
+                    modelId=self.model_id,
+                    body=body,
+                    contentType="application/json",
+                    accept="application/json",
+                )
+                data = json.loads(resp["body"].read())
+                sql_query = (
+                    data["output"]["message"]["content"][0]["text"]
+                    .strip()
+                    .split(";")[0]
+                )
+                logger.info("LLM-generated SQL query: %s", sql_query)
+            except (
+                KeyError,
+                IndexError,
+                TypeError,
+                BotoCoreError,
+                ClientError,
+                NoCredentialsError,
+            ) as exc:
+                logger.warning("LLM SQL generation failed: %s", exc)
+                self.use_llm = False
+
+        if not sql_query:
+            # Keyword-based fallback
+            words = [w.lower() for w in query.split() if w]
+            if words:
+                conditions = " OR ".join(
+                    [
+                        "LOWER(address) LIKE '%{w}%' OR LOWER(location) LIKE '%{w}%' OR LOWER(description) LIKE '%{w}%'".format(
+                            w=w
+                        )
+                        for w in words
+                    ]
+                )
+            else:
+                conditions = "1=1"
+            sql_query = (
+                "SELECT id, address, location, price, description, image FROM properties "
+                f"WHERE {conditions} LIMIT {self.limit}"
+            )
+
         return {
             "result_type": "sql_query",
             "content": sql_query,


### PR DESCRIPTION
## Summary
- enhance SQLQueryGeneratorAgent to leverage Amazon Bedrock to craft SQL from natural language
- fall back to keyword search if LLM generation fails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a49114c1408326af530e48991574d2