### PR TITLE
Add agent tab map and remove SQL result limit

### DIFF
--- a/backend/agents/search.py
+++ b/backend/agents/search.py
@@ -22,7 +22,7 @@ class PropertySearchAgent(Agent):
     """Retrieve property listings and format them as cards."""
 
     def __init__(
-        self, data_file: Path | str | None = None, limit: int = 3, registry=None
+        self, data_file: Path | str | None = None, registry=None
     ) -> None:
         """Create a search agent backed by the CSV listings dataset.
 
@@ -40,17 +40,16 @@ class PropertySearchAgent(Agent):
                 / "listings.csv"
             )
         # self.retriever = SQLPropertyRetriever(data_file)
-        self.generator = SQLQueryGeneratorAgent(limit=limit)
+        self.generator = SQLQueryGeneratorAgent()
         self.executor = SQLQueryExecutorAgent(data_file)
         self.validator = SQLValidatorAgent()
-        self.limit = limit
 
     async def handle(self, query: str, **_: Any) -> Dict[str, Any]:
         logger.debug("Searching properties for query: %s", query)
         print(f"PropertySearchAgent triggered with query: {query}")
         try:
             # listings: List[Dict[str, Any]] = await asyncio.to_thread(
-            #     self.retriever.search, query, self.limit
+            #     self.retriever.search, query
             # )
             gen_res = await self.generator.handle(query=query)
             sql_query = gen_res.get("content", "")

--- a/backend/agents/sql.py
+++ b/backend/agents/sql.py
@@ -24,13 +24,11 @@ class SQLQueryGeneratorAgent(Agent):
 
     def __init__(
         self,
-        limit: int = 5,
         registry=None,
         model_id: str = "amazon.nova-lite-v1:0",
         region: str = "us-east-1",
     ) -> None:
         super().__init__("SQLQueryGeneratorAgent", registry)
-        self.limit = limit
         # Attempt to create a Bedrock client for LLM-powered SQL generation.
         # If client creation fails we fall back to keyword search.
         try:
@@ -49,9 +47,8 @@ class SQLQueryGeneratorAgent(Agent):
             prompt = (
                 "You are an assistant that writes SQLite SQL queries for a table "
                 "'properties' with columns id, address, location, price, "
-                "description, image. "
+                "description, image, lat, lng. "
                 f"Generate a SQL query that answers the user's request: {query}. "
-                f"Limit the results to {self.limit} rows. "
                 "Return only the SQL query."
             )
             body = json.dumps(
@@ -100,8 +97,8 @@ class SQLQueryGeneratorAgent(Agent):
             else:
                 conditions = "1=1"
             sql_query = (
-                "SELECT id, address, location, price, description, image FROM properties "
-                f"WHERE {conditions} LIMIT {self.limit}"
+                "SELECT id, address, location, price, description, image, lat, lng FROM properties "
+                f"WHERE {conditions}"
             )
 
         return {

--- a/backend/langgraph_app.py
+++ b/backend/langgraph_app.py
@@ -195,6 +195,8 @@ async def format_agent(state: GraphState) -> GraphState:
                 else p.get("price", "N/A")
             ),
             "description": p.get("description", ""),
+            "lat": p.get("lat"),
+            "lng": p.get("lng"),
         }
         for p in state.get("listings", [])
     ]

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -270,6 +270,7 @@ button:hover{
 /* Views */
 .sourcing-view { display:flex; flex-direction:column; height:100%; }
 #map { min-height: 380px; width: 100%; border-radius: 12px; overflow: hidden; margin-right:0; margin-bottom:var(--gap); }
+#agent-map { min-height: 380px; width: 100%; border-radius: 12px; overflow: hidden; margin-bottom:var(--gap); }
 .sourcing-view #grid { width:100%; margin-top:2%;  backdrop-filter:blur(5px); flex:1; overflow-y:auto;}
 
 
@@ -300,7 +301,7 @@ button:hover{
 .timeline { height:120px; background:var(--card); border-radius:var(--radius-lg); padding:var(--gap); overflow-y:auto; }
 
 /* Agent chat */
-.agent-chat { display:flex; align-items:center; justify-content:center; height:100%; width:100%; }
+.agent-chat { display:flex; flex-direction:column; align-items:center; justify-content:flex-start; height:100%; width:100%; }
 .chat-box {
   width:100%;
   max-width:800px;


### PR DESCRIPTION
## Summary
- Display chat results on a map in the Agent tab with red markers and only show cards for the latest reply.
- Extend SQL property retrieval with latitude/longitude and drop query result limits.
- Include coordinates in API responses so frontend mapping works.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4964cc88c8326ab9fe79f83ebabb8