### PR TITLE
feat: add LLM-based SQL query generation

### DIFF
--- a/tests/test_sql_query_generator_ai.py
+++ b/tests/test_sql_query_generator_ai.py
@@ -1,0 +1,25 @@
+import asyncio
+import os
+import sys
+
+# Ensure repository root on path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from backend.agents.sql import SQLQueryGeneratorAgent
+
+
+class DummyLLM:
+    def __init__(self):
+        self.last_request = None
+
+    def generate_sql_query(self, request: str) -> str:
+        self.last_request = request
+        return "SELECT * FROM properties"  # simple deterministic query
+
+
+def test_generator_uses_llm():
+    llm = DummyLLM()
+    agent = SQLQueryGeneratorAgent(llm=llm)
+    result = asyncio.run(agent.handle(query="beach house"))
+    assert result["content"] == "SELECT * FROM properties"
+    assert llm.last_request == "beach house"


### PR DESCRIPTION
## Summary
- integrate LLM-based query generation in SQLQueryGeneratorAgent
- add LLMClient.generate_sql_query for properties table
- cover generator with unit test using a stub LLM

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a49eee04f8832690ede5ee4d982d54