### PR TITLE
Handle 'all properties' requests in SQL generator

### DIFF
--- a/tests/test_sql_executor_fallback.py
+++ b/tests/test_sql_executor_fallback.py
@@ -1,0 +1,46 @@
+import asyncio
+import csv
+from pathlib import Path
+
+from backend.agents.sql import SQLQueryExecutorAgent
+
+
+def test_executor_falls_back_to_singular_filename(tmp_path):
+    csv_path = tmp_path / "listing.csv"
+    with csv_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f,
+            [
+                "Listing Number",
+                "Address",
+                "City",
+                "State",
+                "List Price",
+                "Property Subtype",
+                "Image",
+                "Latitude",
+                "Longitude",
+            ],
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "Listing Number": "1",
+                "Address": "123 Main St",
+                "City": "Doral",
+                "State": "FL",
+                "List Price": "1000000",
+                "Property Subtype": "Warehouse",
+                "Image": "",
+                "Latitude": "0",
+                "Longitude": "0",
+            }
+        )
+
+    # Provide a path that points to a non-existent "listings.csv"
+    agent = SQLQueryExecutorAgent(csv_path.with_name("listings.csv"))
+
+    result = asyncio.run(agent.handle("SELECT * FROM properties"))
+    rows = result.get("content", [])
+    assert len(rows) == 1
+    assert rows[0]["address"] == "123 Main St"

--- a/tests/test_sql_query_generator_fallback.py
+++ b/tests/test_sql_query_generator_fallback.py
@@ -1,0 +1,19 @@
+import asyncio
+import os
+import sys
+
+# Ensure repository root on path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from backend.agents.sql import SQLQueryGeneratorAgent
+
+
+class DummyLLM:
+    def generate_sql_query(self, request: str) -> str:
+        return ""  # Force fallback logic
+
+
+def test_all_properties_query_returns_all_rows():
+    agent = SQLQueryGeneratorAgent(llm=DummyLLM())
+    result = asyncio.run(agent.handle(query="show me all properties"))
+    assert result["content"].strip().lower() == "select * from properties where 1=1 limit 10"


### PR DESCRIPTION
## Summary
- Return an unfiltered query when user requests "all properties"
- Cover the fallback behavior with an automated test
- Allow SQL executor to fall back to `listing.csv` when `listings.csv` is absent
- Exercise the new path handling with a regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4e52f1bb483269a3d4a9141349b78