### PR TITLE
fix: ensure agent map displays fully

### DIFF
--- a/frontend/components/agent-chat.js
+++ b/frontend/components/agent-chat.js
@@ -36,7 +36,8 @@ export function createAgentChat() {
       setTimeout(initMap, 300);
     }
   }
-  initMap();
+  // Initialize the map after the element is in the DOM to ensure proper sizing
+  setTimeout(initMap, 0);
 
   function updateMap(props) {
     if (!map) return;

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -272,8 +272,9 @@ button:hover{
 #map { min-height: 380px; width: 100%; border-radius: 12px; overflow: hidden; margin-right:0; margin-bottom:var(--gap); }
 #agent-map {
   min-height: 380px;
-/*   height: 700px; */
   flex: 1;
+  height: 100%;
+  width: 100%;
   border-radius: 12px;
   overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- defer agent map initialization until after DOM insertion to avoid sizing issues
- expand agent tab map container to full available size

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a77cda5cd88326b13196d3e4be4ec6