### PR TITLE
feat: add Google Calendar auth

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -44,6 +44,68 @@ window.mapReady = mapReady;
 const state={ data:{}, gmap:null, markers:{}, activeMarkerId:null };
 let topbarAPI;
 let agentChatEl;
+let googleTokenClient;
+
+async function authFetch(url, options = {}) {
+  try {
+    const token = (await window.aws_amplify.Auth.currentSession())
+      .getIdToken()
+      .getJwtToken();
+    options.headers = { ...(options.headers || {}), Authorization: token };
+  } catch {}
+  return fetch(url, options);
+}
+
+function initGoogleAuth() {
+  if (!window.google || !window.google.accounts || !window.GOOGLE_CLIENT_ID) {
+    setTimeout(initGoogleAuth, 500);
+    return;
+  }
+  googleTokenClient = window.google.accounts.oauth2.initTokenClient({
+    client_id: window.GOOGLE_CLIENT_ID,
+    scope: 'https://www.googleapis.com/auth/calendar.readonly',
+    callback: async resp => {
+      if (resp.access_token) {
+        window.GOOGLE_CALENDAR_ACCESS_TOKEN = resp.access_token;
+        localStorage.setItem('gcal_token', resp.access_token);
+        try {
+          await authFetch(`${window.API_BASE_URL}/google-token`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ access_token: resp.access_token })
+          });
+        } catch {}
+        router();
+      }
+    }
+  });
+}
+
+async function ensureGoogleAccessToken() {
+  if (window.GOOGLE_CALENDAR_ACCESS_TOKEN)
+    return window.GOOGLE_CALENDAR_ACCESS_TOKEN;
+  const stored = localStorage.getItem('gcal_token');
+  if (stored) {
+    window.GOOGLE_CALENDAR_ACCESS_TOKEN = stored;
+    return stored;
+  }
+  try {
+    const resp = await authFetch(`${window.API_BASE_URL}/google-token`);
+    if (resp.ok) {
+      const data = await resp.json();
+      if (data.access_token) {
+        window.GOOGLE_CALENDAR_ACCESS_TOKEN = data.access_token;
+        localStorage.setItem('gcal_token', data.access_token);
+        return data.access_token;
+      }
+    }
+  } catch {}
+  return null;
+}
+
+function requestGoogleAccessToken() {
+  if (googleTokenClient) googleTokenClient.requestAccessToken();
+}
 
 function fetchGoogleCalendarEvents() {
   const token = window.GOOGLE_CALENDAR_ACCESS_TOKEN;
@@ -84,6 +146,7 @@ function startApp(){
     state.data=d;
     init();
   });
+  initGoogleAuth();
 }
 
 startApp();
@@ -409,11 +472,20 @@ function router(){
       const calendarWrap=document.createElement('div');
       calendarWrap.className='leads-calendar';
       calendarWrap.innerHTML='<h3>Calendar</h3>';
+      const syncBtn=document.createElement('button');
+      syncBtn.textContent='Sync Google Calendar';
+      syncBtn.addEventListener('click',requestGoogleAccessToken);
+      calendarWrap.appendChild(syncBtn);
       layout.appendChild(calendarWrap);
       main.appendChild(layout);
 
-      fetchGoogleCalendarEvents().then(events => {
-        calendarWrap.appendChild(createEventCalendar(events));
+      ensureGoogleAccessToken().then(token=>{
+        if(token){
+          fetchGoogleCalendarEvents().then(events=>{
+            calendarWrap.appendChild(createEventCalendar(events));
+          });
+          syncBtn.style.display='none';
+        }
       });
 
       const params=new URLSearchParams(query||'');

--- a/frontend/config.sample.js
+++ b/frontend/config.sample.js
@@ -21,3 +21,8 @@ window.GOOGLE_CALENDAR_ID = 'YOUR_CALENDAR_ID';
 // Optional OAuth access token for loading a user's private calendar.
 // If set, the app will read events from that user's primary calendar.
 window.GOOGLE_CALENDAR_ACCESS_TOKEN = '';
+
+// Client ID for Google Identity Services, used to authorize access to a user's
+// Google Calendar. Provide this if you want users to sign in and sync their
+// personal calendars.
+window.GOOGLE_CLIENT_ID = 'YOUR_GOOGLE_CLIENT_ID';

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,6 +21,7 @@
     <div id="toast-container"></div>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/aws-amplify@latest/dist/aws-amplify.min.js"></script>
+  <script src="https://accounts.google.com/gsi/client" async defer></script>
   <script src="config.js"></script>
   <script>
     const { Amplify, Auth } = aws_amplify;


### PR DESCRIPTION
## Summary
- add FastAPI endpoints to store per-user Google Calendar tokens
- enable Google Identity sign-in and calendar syncing on leads page
- extend configuration with Google client ID and auth script

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae07bbd73483269447dc1b74d1f8c8