### PR TITLE
Ensure Google Calendar sync button renders events

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -489,14 +489,18 @@ function router(){
       const syncBtn=document.createElement('button');
       syncBtn.textContent='Sync Google Calendar';
       function renderCalendar(){
+        calendarWrap.innerHTML='<h3>Calendar</h3>';
         fetchGoogleCalendarEvents().then(events=>{
           calendarWrap.appendChild(createEventCalendar(events));
         });
-        syncBtn.style.display='none';
       }
       syncBtn.addEventListener('click',()=>{
-        onGoogleToken(renderCalendar);
-        requestGoogleAccessToken();
+        if(window.GOOGLE_CALENDAR_ACCESS_TOKEN){
+          renderCalendar();
+        } else {
+          onGoogleToken(renderCalendar);
+          requestGoogleAccessToken();
+        }
       });
       calendarWrap.appendChild(syncBtn);
       layout.appendChild(calendarWrap);


### PR DESCRIPTION
## Summary
- Clear and rebuild the leads page calendar container when syncing
- Render calendar events immediately when a token exists, avoiding no-op clicks
- Request Google access token only when necessary

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae1897d5888326bf47685824e060df