### PR TITLE
Add Google Calendar link button to leads page

### DIFF
--- a/backend/appointments.py
+++ b/backend/appointments.py
@@ -14,9 +14,11 @@ except ImportError:  # fallback when run as script
 
 try:  # Optional dependency; module may be absent in test environments
     from google.oauth2 import service_account
+    from google.oauth2.credentials import Credentials
     from googleapiclient.discovery import build
 except Exception:  # pragma: no cover - handled gracefully when unavailable
     service_account = None  # type: ignore
+    Credentials = None  # type: ignore
     build = None  # type: ignore
 
 
@@ -162,9 +164,34 @@ def book_appointment(
     end = dt + timedelta(hours=1)
     description = f"Phone: {payload.phone}\nEmail: {payload.email}"
     summary = f"Appointment with {payload.name}"
+    event_body = {
+        "summary": summary,
+        "start": {"dateTime": dt.isoformat(), "timeZone": "UTC"},
+        "end": {"dateTime": end.isoformat(), "timeZone": "UTC"},
+        "description": description,
+        "attendees": [{"email": payload.email}],
+    }
     event = _calendar.create_event(
         summary, dt, end, description, attendees=[payload.email]
     )
+
+    # Also create the event on the user's linked Google Calendar if a token is stored
+    try:  # pragma: no cover - graceful degradation when token missing
+        from . import web_app  # type: ignore
+
+        key = user["sub"] if user else "default"
+        token = web_app._google_tokens.get(key)
+        if token and Credentials and build:
+            creds = Credentials(token)
+            service = build("calendar", "v3", credentials=creds)
+            (
+                service.events()
+                .insert(calendarId="primary", body=event_body, sendUpdates="all")
+                .execute()
+            )
+    except Exception:
+        pass
+
     return {"event": event}
 
 

--- a/backend/web_app.py
+++ b/backend/web_app.py
@@ -135,3 +135,17 @@ async def get_google_token(user: dict | None = Depends(get_current_user)):
     key = user["sub"] if user else "default"
     token = _google_tokens.get(key)
     return {"access_token": token}
+
+
+@app.delete("/google-token")
+async def delete_google_token(user: dict | None = Depends(get_current_user)):
+    """Remove the stored Google OAuth token for the authenticated user."""
+    if AUTH_ENABLED and not user:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    key = user["sub"] if user else "default"
+    _google_tokens.pop(key, None)
+    try:
+        _TOKENS_FILE.write_text(json.dumps(_google_tokens))
+    except Exception:
+        logging.exception("Failed to persist Google token")
+    return {"status": "deleted"}

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -507,11 +507,6 @@ function router(){
       const calendarWrap=document.createElement('div');
       calendarWrap.className='leads-calendar';
       calendarWrap.innerHTML='<h3>Calendar</h3>';
-      const openCalBtn=document.createElement('button');
-      openCalBtn.textContent='Open Google Calendar';
-      openCalBtn.addEventListener('click',()=>{
-        window.open('https://calendar.google.com/calendar/u/0/r','_blank');
-      });
       const syncBtn=document.createElement('button');
       syncBtn.textContent='Sync Google Calendar';
       let calendarEl=createEventCalendar();
@@ -527,7 +522,7 @@ function router(){
         onGoogleToken(renderCalendar);
         requestGoogleAccessToken();
       });
-      calendarWrap.append(openCalBtn,syncBtn,calendarEl);
+      calendarWrap.append(syncBtn,calendarEl);
       layout.appendChild(calendarWrap);
       main.appendChild(layout);
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -493,9 +493,12 @@ function router(){
       });
       const syncBtn=document.createElement('button');
       syncBtn.textContent='Sync Google Calendar';
+      let calendarEl=createEventCalendar();
       function renderCalendar(){
         fetchGoogleCalendarEvents().then(events=>{
-          calendarWrap.appendChild(createEventCalendar(events));
+          const newEl=createEventCalendar(events);
+          calendarEl.replaceWith(newEl);
+          calendarEl=newEl;
         });
         syncBtn.style.display='none';
       }
@@ -503,7 +506,7 @@ function router(){
         onGoogleToken(renderCalendar);
         requestGoogleAccessToken();
       });
-      calendarWrap.append(openCalBtn,syncBtn);
+      calendarWrap.append(openCalBtn,syncBtn,calendarEl);
       layout.appendChild(calendarWrap);
       main.appendChild(layout);
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -486,6 +486,11 @@ function router(){
       const calendarWrap=document.createElement('div');
       calendarWrap.className='leads-calendar';
       calendarWrap.innerHTML='<h3>Calendar</h3>';
+      const openCalBtn=document.createElement('button');
+      openCalBtn.textContent='Open Google Calendar';
+      openCalBtn.addEventListener('click',()=>{
+        window.open('https://calendar.google.com/calendar/u/0/r','_blank');
+      });
       const syncBtn=document.createElement('button');
       syncBtn.textContent='Sync Google Calendar';
       function renderCalendar(){
@@ -498,7 +503,7 @@ function router(){
         onGoogleToken(renderCalendar);
         requestGoogleAccessToken();
       });
-      calendarWrap.appendChild(syncBtn);
+      calendarWrap.append(openCalBtn,syncBtn);
       layout.appendChild(calendarWrap);
       main.appendChild(layout);
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -125,6 +125,9 @@ function requestGoogleAccessToken() {
 
 function fetchGoogleCalendarEvents() {
   const token = window.GOOGLE_CALENDAR_ACCESS_TOKEN;
+  const now = new Date();
+  const timeMin = new Date(now.getFullYear(), 0, 1).toISOString();
+  const timeMax = new Date(now.getFullYear() + 1, 0, 1).toISOString();
   if (token) {
     return fetch('https://www.googleapis.com/calendar/v3/users/me/calendarList', {
       headers: { Authorization: `Bearer ${token}` }
@@ -137,7 +140,9 @@ function fetchGoogleCalendarEvents() {
             fetch(
               `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(
                 cal.id
-              )}/events?singleEvents=true&orderBy=startTime`,
+              )}/events?singleEvents=true&orderBy=startTime&timeMin=${encodeURIComponent(
+                timeMin
+              )}&timeMax=${encodeURIComponent(timeMax)}`,
               { headers: { Authorization: `Bearer ${token}` } }
             )
               .then(r => r.json())
@@ -158,7 +163,9 @@ function fetchGoogleCalendarEvents() {
   if (!calendarId || !apiKey) return Promise.resolve([]);
   const url = `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(
     calendarId
-  )}/events?key=${apiKey}&singleEvents=true&orderBy=startTime`;
+  )}/events?key=${apiKey}&singleEvents=true&orderBy=startTime&timeMin=${encodeURIComponent(
+    timeMin
+  )}&timeMax=${encodeURIComponent(timeMax)}`;
   return fetch(url)
     .then(r => r.json())
     .then(data => (data.items || []).map(ev => ({

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -72,7 +72,7 @@ function initGoogleAuth() {
   const redirectUri = window.GOOGLE_REDIRECT_URI || window.location.origin;
   googleTokenClient = window.google.accounts.oauth2.initTokenClient({
     client_id: window.GOOGLE_CLIENT_ID,
-    scope: 'https://www.googleapis.com/auth/calendar.readonly',
+    scope: 'https://www.googleapis.com/auth/calendar',
     redirect_uri: redirectUri,
     callback: async resp => {
       if (resp.access_token) {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -69,9 +69,11 @@ function initGoogleAuth() {
     setTimeout(initGoogleAuth, 500);
     return;
   }
+  const redirectUri = window.GOOGLE_REDIRECT_URI || window.location.origin;
   googleTokenClient = window.google.accounts.oauth2.initTokenClient({
     client_id: window.GOOGLE_CLIENT_ID,
     scope: 'https://www.googleapis.com/auth/calendar.readonly',
+    redirect_uri: redirectUri,
     callback: async resp => {
       if (resp.access_token) {
         window.GOOGLE_CALENDAR_ACCESS_TOKEN = resp.access_token;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -509,6 +509,9 @@ function router(){
       calendarWrap.innerHTML='<h3>Calendar</h3>';
       const syncBtn=document.createElement('button');
       syncBtn.textContent='Sync Google Calendar';
+      const unlinkBtn=document.createElement('button');
+      unlinkBtn.textContent='Unlink Google Calendar';
+      unlinkBtn.style.display='none';
       let calendarEl=createEventCalendar();
       function renderCalendar(){
         fetchGoogleCalendarEvents().then(events=>{
@@ -517,12 +520,27 @@ function router(){
           calendarEl=newEl;
         });
         syncBtn.style.display='none';
+        unlinkBtn.style.display='';
       }
       syncBtn.addEventListener('click',()=>{
         onGoogleToken(renderCalendar);
         requestGoogleAccessToken();
       });
-      calendarWrap.append(syncBtn,calendarEl);
+      unlinkBtn.addEventListener('click',()=>{
+        const token=window.GOOGLE_CALENDAR_ACCESS_TOKEN;
+        if(token){
+          fetch(`https://oauth2.googleapis.com/revoke?token=${token}`,{method:'POST'}).catch(()=>{});
+        }
+        authFetch(`${window.API_BASE_URL}/google-token`,{method:'DELETE'}).catch(()=>{});
+        delete window.GOOGLE_CALENDAR_ACCESS_TOKEN;
+        localStorage.removeItem('gcal_token');
+        const newEl=createEventCalendar();
+        calendarEl.replaceWith(newEl);
+        calendarEl=newEl;
+        syncBtn.style.display='';
+        unlinkBtn.style.display='none';
+      });
+      calendarWrap.append(syncBtn,unlinkBtn,calendarEl);
       layout.appendChild(calendarWrap);
       main.appendChild(layout);
 

--- a/frontend/config.sample.js
+++ b/frontend/config.sample.js
@@ -26,3 +26,8 @@ window.GOOGLE_CALENDAR_ACCESS_TOKEN = '';
 // Google Calendar. Provide this if you want users to sign in and sync their
 // personal calendars.
 window.GOOGLE_CLIENT_ID = 'YOUR_GOOGLE_CLIENT_ID';
+
+// Redirect URI registered for the OAuth client. By default the application
+// uses its current origin, but you can override this if your Google Cloud
+// console specifies a different authorized redirect URI.
+window.GOOGLE_REDIRECT_URI = '';

--- a/tests/test_appointment_endpoints.py
+++ b/tests/test_appointment_endpoints.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from backend.langgraph_app import app
+from backend.appointments import _calendar
 
 
 def test_appointment_routes():
@@ -27,3 +28,5 @@ def test_appointment_routes():
     resp = client.post("/appointments", json=payload)
     assert resp.status_code == 200
     assert "event" in resp.json()
+    # Attendee email should be recorded on the event
+    assert _calendar._local_events[0]["attendees"] == [payload["email"]]

--- a/tests/test_appointment_endpoints.py
+++ b/tests/test_appointment_endpoints.py
@@ -30,3 +30,53 @@ def test_appointment_routes():
     assert "event" in resp.json()
     # Attendee email should be recorded on the event
     assert _calendar._local_events[0]["attendees"] == [payload["email"]]
+
+
+def test_appointment_creates_user_event(monkeypatch):
+    client = TestClient(app)
+    from backend import web_app
+
+    web_app._google_tokens["default"] = "token123"
+
+    captured = {}
+
+    class DummyCreds:
+        def __init__(self, token):
+            captured["token"] = token
+
+    class DummyEvents:
+        def insert(self, calendarId, body, sendUpdates):
+            captured["calendarId"] = calendarId
+            captured["body"] = body
+            captured["sendUpdates"] = sendUpdates
+
+            class Exec:
+                def execute(self):
+                    return {}
+
+            return Exec()
+
+    class DummyService:
+        def events(self):
+            return DummyEvents()
+
+    def fake_build(api, ver, credentials):
+        captured["api"] = api
+        return DummyService()
+
+    monkeypatch.setattr("backend.appointments.Credentials", DummyCreds)
+    monkeypatch.setattr("backend.appointments.build", fake_build)
+
+    payload = {
+        "name": "Bob",
+        "phone": "555",
+        "email": "bob@example.com",
+        "date": "2024-01-02",
+        "time": "10:00 AM",
+    }
+    resp = client.post("/appointments", json=payload)
+    assert resp.status_code == 200
+    assert captured["token"] == "token123"
+    assert captured["calendarId"] == "primary"
+    assert captured["sendUpdates"] == "all"
+    assert captured["body"]["attendees"][0]["email"] == payload["email"]

--- a/tests/test_appointments_fallback.py
+++ b/tests/test_appointments_fallback.py
@@ -23,9 +23,10 @@ def test_fallback_creates_local_event(monkeypatch):
     start = datetime(2024, 1, 1, 10, 0)
     end = datetime(2024, 1, 1, 11, 0)
 
-    event = client.create_event("Test", start, end, "desc")
+    event = client.create_event("Test", start, end, "desc", attendees=["a@example.com"])
     assert "id" in event
 
     events = client.list_events()
     assert len(events) == 1
     assert events[0]["summary"] == "Test"
+    assert events[0]["attendees"] == ["a@example.com"]

--- a/tests/test_google_token_endpoints.py
+++ b/tests/test_google_token_endpoints.py
@@ -55,3 +55,10 @@ def test_google_token_roundtrip(tmp_path):
     resp = client.get("/google-token")
     assert resp.status_code == 200
     assert resp.json()["access_token"] == "abc"
+
+    # delete the token and ensure it is cleared
+    resp = client.delete("/google-token")
+    assert resp.status_code == 200
+    resp = client.get("/google-token")
+    assert resp.status_code == 200
+    assert resp.json() == {"access_token": None}


### PR DESCRIPTION
## Summary
- Add "Open Google Calendar" button on the leads page calendar panel
- Keep sync functionality while allowing quick access to the Google Calendar site

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae1a4a77dc8326b36c161683215e42