### PR TITLE
Persist user-specific leads with Postgres-ready backend

### DIFF
--- a/backend/langgraph_app.py
+++ b/backend/langgraph_app.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel
 try:  # pragma: no cover - support running as package or script
     from .appointments import router as appointments_router
     from .auth import get_current_user
+    from .leads import router as leads_router
     from .agents.sql import (
         SQLQueryExecutorAgent,
         SQLQueryGeneratorAgent,
@@ -25,6 +26,7 @@ try:  # pragma: no cover - support running as package or script
 except ImportError:  # fallback for running from the backend directory directly
     from appointments import router as appointments_router
     from auth import get_current_user
+    from leads import router as leads_router
     from agents.sql import (
         SQLQueryExecutorAgent,
         SQLQueryGeneratorAgent,
@@ -246,4 +248,5 @@ async def chat(
 
 
 app.include_router(appointments_router)
+app.include_router(leads_router)
 

--- a/backend/leads.py
+++ b/backend/leads.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+try:  # pragma: no cover - allow running as package or script
+    from .auth import get_current_user
+except ImportError:  # fallback for running from backend directory
+    from auth import get_current_user
+
+try:  # Optional dependency for PostgreSQL
+    import psycopg2  # type: ignore
+except Exception:  # pragma: no cover
+    psycopg2 = None  # type: ignore
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./leads.db")
+
+
+def _is_postgres() -> bool:
+    return DATABASE_URL.startswith("postgres") and psycopg2 is not None
+
+
+def _get_conn():
+    if _is_postgres():
+        return psycopg2.connect(DATABASE_URL)
+    path = DATABASE_URL.replace("sqlite:///", "")
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+# Ensure table exists
+with _get_conn() as _conn:
+    _conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS leads (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT,
+            name TEXT NOT NULL,
+            stage TEXT NOT NULL,
+            property TEXT,
+            email TEXT,
+            phone TEXT,
+            listing_number TEXT,
+            address TEXT,
+            notes TEXT
+        )
+        """
+    )
+    _conn.commit()
+
+
+router = APIRouter()
+
+
+class LeadCreate(BaseModel):
+    name: str
+    stage: str = "New"
+    property: Optional[str] = None
+    email: Optional[str] = None
+    phone: Optional[str] = None
+    listingNumber: Optional[str] = None
+    address: Optional[str] = None
+    notes: Optional[str] = None
+
+
+class LeadUpdate(BaseModel):
+    name: Optional[str] = None
+    stage: Optional[str] = None
+    property: Optional[str] = None
+    email: Optional[str] = None
+    phone: Optional[str] = None
+    listingNumber: Optional[str] = None
+    address: Optional[str] = None
+    notes: Optional[str] = None
+
+
+def _user_id(user: dict | None) -> str:
+    return user.get("sub") if user else "default"
+
+
+def _row_to_dict(row) -> dict:
+    return {
+        "id": row["id"],
+        "name": row["name"],
+        "stage": row["stage"],
+        "property": row["property"],
+        "email": row["email"],
+        "phone": row["phone"],
+        "listingNumber": row["listing_number"],
+        "address": row["address"],
+        "notes": row["notes"],
+    }
+
+
+@router.get("/leads")
+def list_leads(user: dict | None = Depends(get_current_user)) -> List[dict]:
+    uid = _user_id(user)
+    with _get_conn() as conn:
+        rows = conn.execute(
+            "SELECT * FROM leads WHERE user_id = ?" if not _is_postgres() else "SELECT * FROM leads WHERE user_id = %s",
+            (uid,),
+        ).fetchall()
+    return [_row_to_dict(r) for r in rows]
+
+
+@router.post("/leads")
+def create_lead(payload: LeadCreate, user: dict | None = Depends(get_current_user)) -> dict:
+    uid = _user_id(user)
+    values = (
+        uid,
+        payload.name,
+        payload.stage,
+        payload.property,
+        payload.email,
+        payload.phone,
+        payload.listingNumber,
+        payload.address,
+        payload.notes,
+    )
+    with _get_conn() as conn:
+        cur = conn.execute(
+            (
+                "INSERT INTO leads (user_id, name, stage, property, email, phone, listing_number, address, notes) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            )
+            if not _is_postgres()
+            else (
+                "INSERT INTO leads (user_id, name, stage, property, email, phone, listing_number, address, notes) "
+                "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING id"
+            ),
+            values,
+        )
+        if _is_postgres():
+            lead_id = cur.fetchone()[0]
+        else:
+            lead_id = cur.lastrowid
+        conn.commit()
+    return {"id": lead_id}
+
+
+@router.put("/leads/{lead_id}")
+def update_lead(
+    lead_id: int, payload: LeadUpdate, user: dict | None = Depends(get_current_user)
+) -> dict:
+    uid = _user_id(user)
+    data = payload.dict(exclude_unset=True)
+    if not data:
+        return {"status": "ok"}
+    columns = []
+    values = []
+    for field, value in data.items():
+        column = "listing_number" if field == "listingNumber" else field
+        columns.append(f"{column} = {'%s' if _is_postgres() else '?'}")
+        values.append(value)
+    values.extend([uid, lead_id])
+    query = (
+        f"UPDATE leads SET {', '.join(columns)} WHERE user_id = {'%s' if _is_postgres() else '?'} AND id = {'%s' if _is_postgres() else '?'}"
+    )
+    with _get_conn() as conn:
+        cur = conn.execute(query, tuple(values))
+        if cur.rowcount == 0:
+            raise HTTPException(status_code=404, detail="Lead not found")
+        conn.commit()
+    return {"status": "ok"}

--- a/backend/web_app.py
+++ b/backend/web_app.py
@@ -12,6 +12,7 @@ from langgraph_app import app_graph
 from property_chatbot import SonicClient
 from auth import AUTH_ENABLED, get_current_user
 from appointments import router as appointments_router
+from leads import router as leads_router
 import json
 from pathlib import Path
 
@@ -32,6 +33,7 @@ templates = Jinja2Templates(directory="templates")
 # Instantiate shared clients
 _sonic = SonicClient()
 app.include_router(appointments_router)
+app.include_router(leads_router)
 
 
 @app.get("/", response_class=HTMLResponse)

--- a/tests/test_leads_endpoints.py
+++ b/tests/test_leads_endpoints.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import importlib
+
+from fastapi.testclient import TestClient
+
+# Ensure repository root on path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+
+def override_user(user_id):
+    def _user():
+        return {"sub": user_id}
+    return _user
+
+
+def create_app(tmp_path):
+    db_url = f"sqlite:///{tmp_path}/test_leads.db"
+    os.environ["DATABASE_URL"] = db_url
+    # Reload leads module with new DATABASE_URL
+    import backend.leads as leads
+    importlib.reload(leads)
+    from fastapi import FastAPI
+    app = FastAPI()
+    app.include_router(leads.router)
+    from backend import auth
+    app.dependency_overrides[auth.get_current_user] = override_user("user1")
+    return app
+
+
+def test_leads_are_scoped_to_user(tmp_path):
+    app = create_app(tmp_path)
+    client = TestClient(app)
+
+    # Create lead for user1
+    resp = client.post("/leads", json={"name": "Alice", "stage": "New"})
+    assert resp.status_code == 200
+    lead_id = resp.json()["id"]
+
+    # Verify user1 sees their lead
+    resp = client.get("/leads")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["name"] == "Alice"
+
+    # Switch to user2 and create lead
+    from backend import auth
+    app.dependency_overrides[auth.get_current_user] = override_user("user2")
+    resp = client.post("/leads", json={"name": "Bob", "stage": "Qualified"})
+    assert resp.status_code == 200
+
+    # User2 should only see their lead
+    resp = client.get("/leads")
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["name"] == "Bob"
+
+    # Switch back to user1 and update stage
+    app.dependency_overrides[auth.get_current_user] = override_user("user1")
+    resp = client.put(f"/leads/{lead_id}", json={"stage": "Contacted"})
+    assert resp.status_code == 200
+
+    resp = client.get("/leads")
+    data = resp.json()
+    assert data[0]["stage"] == "Contacted"


### PR DESCRIPTION
## Summary
- include new `leads` API for persisting Kanban leads in a database
- hook leads routes into existing FastAPI apps
- test user-scoped lead persistence

## Testing
- `pytest -q`
- `pip install sqlalchemy psycopg2-binary` *(fails: Could not find a version that satisfies the requirement sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68af6db094a48326978eb90a6340f7e5