### PR TITLE
Persist user-specific leads with PostgreSQL

### DIFF
--- a/backend/leads.py
+++ b/backend/leads.py
@@ -44,20 +44,39 @@ def _get_cursor(conn):
 with _get_conn() as _conn:
     cur = _get_cursor(_conn)
     cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS leads (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            user_id TEXT,
-            name TEXT NOT NULL,
-            stage TEXT NOT NULL,
-            property TEXT,
-            email TEXT,
-            phone TEXT,
-            listing_number TEXT,
-            address TEXT,
-            notes TEXT
+        (
+            """
+            CREATE TABLE IF NOT EXISTS leads (
+                id SERIAL PRIMARY KEY,
+                user_id TEXT,
+                name TEXT NOT NULL,
+                stage TEXT NOT NULL,
+                property TEXT,
+                email TEXT,
+                phone TEXT,
+                listing_number TEXT,
+                address TEXT,
+                notes TEXT
+            )
+            """
         )
-        """
+        if _is_postgres()
+        else (
+            """
+            CREATE TABLE IF NOT EXISTS leads (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id TEXT,
+                name TEXT NOT NULL,
+                stage TEXT NOT NULL,
+                property TEXT,
+                email TEXT,
+                phone TEXT,
+                listing_number TEXT,
+                address TEXT,
+                notes TEXT
+            )
+            """
+        )
     )
     _conn.commit()
 


### PR DESCRIPTION
## Summary
- Support PostgreSQL by using SERIAL IDs when creating the leads table.
- Load and update user-specific leads via authenticated API calls on the frontend.
- Persist new and edited leads to the database from the leads page.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b21b74be588326a4f613a078cd9fbb