### PR TITLE
Persist user-specific leads with PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,28 @@ AWS_DEFAULT_REGION=us-east-1
 The application automatically loads this file on startup, allowing boto3 to pick
 up the credentials without exporting them manually.
 
+### Local PostgreSQL database
+
+By default, leads are stored in a SQLite file. To persist them in PostgreSQL
+instead:
+
+1. Install PostgreSQL and the Python driver: `pip install psycopg2-binary`.
+2. Create a database, for example:
+
+   ```bash
+   psql -U postgres -c "CREATE DATABASE cascade_ai;"
+   ```
+
+3. Set the connection string in your `.env` file so the backend connects to it:
+
+   ```
+   DATABASE_URL=postgresql://username:password@localhost:5432/cascade_ai
+   ```
+
+   Replace the credentials with those for your local setup.
+
+The `leads` table is created automatically on first run.
+
 ### Google Calendar integration
 
 The appointment booking feature can write events directly to a Google

--- a/tests/test_leads_endpoints.py
+++ b/tests/test_leads_endpoints.py
@@ -64,3 +64,12 @@ def test_leads_are_scoped_to_user(tmp_path):
     resp = client.get("/leads")
     data = resp.json()
     assert data[0]["stage"] == "Contacted"
+
+
+def test_leads_require_authentication(tmp_path):
+    app = create_app(tmp_path)
+    client = TestClient(app)
+    from backend import auth
+    app.dependency_overrides[auth.get_current_user] = lambda: None
+    resp = client.get("/leads")
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- Support PostgreSQL by using SERIAL IDs when creating the leads table.
- Load and update user-specific leads via authenticated API calls on the frontend.
- Persist new and edited leads to the database from the leads page.
- Require authentication for lead access to ensure users only see their own leads.
- Document how to configure a local PostgreSQL database via `DATABASE_URL` in `.env`.
- Warn when authentication is missing and show a clear message when lead requests are unauthorized.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b21b74be588326a4f613a078cd9fbb