### PR TITLE
Ensure frontend API requests require authentication

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -52,9 +52,8 @@ function onGoogleToken(fn){
 }
 
 async function authFetch(url, options = {}) {
-  let token;
   try {
-    token = (await window.aws_amplify.Auth.currentSession())
+    const token = (await window.aws_amplify.Auth.currentSession())
       .getIdToken()
       .getJwtToken();
     options.headers = {
@@ -62,7 +61,8 @@ async function authFetch(url, options = {}) {
       Authorization: `Bearer ${token}`
     };
   } catch (err) {
-    console.warn('No authenticated session; request will be sent without credentials');
+    console.warn('No authenticated session; request cancelled');
+    return new Response(null, { status: 401 });
   }
   const resp = await fetch(url, options);
   if (resp.status === 401) {


### PR DESCRIPTION
## Summary
- Avoid unauthenticated fetch requests in frontend
- Return 401 when no session token is present so leads remain scoped per-user

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b73556b80c8326be488ec16c63ea17