### PR TITLE
Add user-scoped lead deletion and UI remove option

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -599,7 +599,14 @@ async function router(){
             board.render();
           });
         },
-        onOpen:lead=>openLeadForm(lead)
+        onOpen:lead=>openLeadForm(lead),
+        onDelete:l=>{
+          authFetch(`${window.API_BASE_URL}/leads/${l.id}`,{method:'DELETE'}).then(()=>{
+            const i=state.data.leads.findIndex(x=>x.id===l.id);
+            if(i>-1) state.data.leads.splice(i,1);
+            board.render();
+          });
+        }
       });
       layout.appendChild(board.el);
       const calendarWrap=document.createElement('div');

--- a/frontend/components/kanban.js
+++ b/frontend/components/kanban.js
@@ -4,7 +4,7 @@ import { showToast } from './toast.js';
 let stages = ['New', 'Contacted', 'Qualified', 'Proposal', 'Closed'];
 
 export function createKanban(leads = [], callbacks = {}) {
-  const { onAdd, onEdit, onOpen } = callbacks;
+  const { onAdd, onEdit, onOpen, onDelete } = callbacks;
   const board = document.createElement('div');
   board.className = 'kanban';
 
@@ -136,6 +136,14 @@ export function createKanban(leads = [], callbacks = {}) {
       }${l.listingNumber ? `<br/><small>${l.listingNumber}</small>` : ''}${
         l.address ? `<br/><small>${l.address}</small>` : ''
       }`;
+      const del = document.createElement('button');
+      del.textContent = '✕';
+      del.className = 'delete-lead';
+      del.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (onDelete) onDelete(l);
+      });
+      card.appendChild(del);
       card.addEventListener('dragstart', (e) =>
         e.dataTransfer.setData('id', card.id)
       );

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -309,9 +309,10 @@ button:hover{
 .leads-page {display:flex;flex-direction:row;gap:var(--gap);}
 .leads-page .kanban {flex:1;order:1;}
 .leads-page .leads-calendar {width:300px;background:var(--card);border-radius:var(--radius-lg);padding:var(--gap);order:2;}
-.lead-card { background:var(--muted); border-radius:var(--radius-sm); padding:var(--gap); margin-bottom:var(--gap); cursor:grab; }
+.lead-card { background:var(--muted); border-radius:var(--radius-sm); padding:var(--gap); margin-bottom:var(--gap); cursor:grab; position:relative; }
 .lead-card { transition:background 0.3s, box-shadow 0.3s; }
 .lead-card:hover { background:var(--card); box-shadow:0 0 8px var(--accent); }
+.lead-card .delete-lead { position:absolute; top:4px; right:4px; background:none; border:none; cursor:pointer; }
 
 .outreach-view { display:flex; height:100%; gap:var(--gap); }
 .cohorts { width:220px; background:var(--card); border-radius:var(--radius-lg); padding:var(--gap); overflow-y:auto; }


### PR DESCRIPTION
## Summary
- Add DELETE `/leads/{id}` endpoint scoped by user ID and email
- Expose delete icon in Kanban lead cards and wire to backend
- Style lead delete button and test user-scoped deletion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b74cef94508326abf33c521cf8f9f8