### PR TITLE
Add Gmail sync flow with runtime credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,24 @@ and remember the OAuth credentials for future sessions. To enable this flow:
    next login the application will fetch events from Google Calendar without
    prompting you again.
 
+### Email integration (Gmail and Outlook)
+
+The backend can display recent emails from popular providers.
+
+- **Gmail** – Users supply their Gmail address and app password at runtime by
+  POSTing to `/emails/gmail/sync`. The credentials are stored in memory for the
+  session and used when subsequently calling `GET /emails/gmail`.
+- **Outlook** – Continue to provide credentials via environment variables and
+  call `GET /emails/outlook`.
+
+```
+OUTLOOK_USERNAME=user@example.com
+OUTLOOK_PASSWORD=your_password
+```
+
+When credentials are missing the endpoints return an empty list so the rest of
+the application continues to function.
+
 ## Notes
 
 This example focuses on illustrating how components fit together. Production applications should implement robust error handling, streaming audio for low latency, and secure storage of user data.

--- a/backend/README.md
+++ b/backend/README.md
@@ -39,6 +39,24 @@ want to use:
 If these variables are omitted the server falls back to an in-memory store and
 appointments will not persist across restarts.
 
+### Optional: Email integration
+
+The backend exposes endpoints for viewing emails from Gmail or Outlook.
+
+- **Gmail** – Users provide their Gmail address and app password via a POST to
+  `/emails/gmail/sync`. The server stores the credentials in memory and uses
+  them when handling `GET /emails/gmail`.
+- **Outlook** – Supply credentials via environment variables and call
+  `GET /emails/outlook`.
+
+```
+OUTLOOK_USERNAME=user@example.com
+OUTLOOK_PASSWORD=your_password
+```
+
+If credentials are missing or incorrect the endpoint returns an empty list
+instead of raising an error.
+
 ## REST API
 
 Start the server:

--- a/backend/emails.py
+++ b/backend/emails.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+"""Helpers for fetching email from popular providers.
+
+These utilities use IMAP with credentials supplied via environment variables.
+The goal is to offer a simple way for the application to display a user's
+emails inside the real‑estate assistant. When credentials are missing or the
+connection fails, the helpers return an empty list instead of raising
+exceptions so the rest of the application can continue to function.
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional
+import email
+import imaplib
+import os
+
+
+@dataclass
+class EmailMessage:
+    """Minimal representation of an email message."""
+
+    id: str
+    subject: str
+    sender: str
+    snippet: str = ""
+
+
+class BaseEmailProvider:
+    """Common interface for email providers."""
+
+    def list_messages(self, max_results: int = 10) -> List[EmailMessage]:
+        raise NotImplementedError
+
+
+class GmailProvider(BaseEmailProvider):
+    """Fetch messages from a Gmail inbox via IMAP."""
+
+    SERVER = "imap.gmail.com"
+
+    def __init__(self, username: Optional[str] = None, password: Optional[str] = None) -> None:
+        self.username = username or os.getenv("GMAIL_USERNAME")
+        self.password = password or os.getenv("GMAIL_PASSWORD")
+
+    def list_messages(self, max_results: int = 10) -> List[EmailMessage]:
+        if not self.username or not self.password:
+            return []
+        try:
+            with imaplib.IMAP4_SSL(self.SERVER) as imap:
+                imap.login(self.username, self.password)
+                imap.select("inbox")
+                _typ, data = imap.search(None, "ALL")
+                ids = data[0].split()[-max_results:]
+                messages: List[EmailMessage] = []
+                for num in ids:
+                    _typ, msg_data = imap.fetch(num, "(BODY.PEEK[HEADER.FIELDS (SUBJECT FROM)])")
+                    raw = msg_data[0][1]
+                    msg = email.message_from_bytes(raw)
+                    messages.append(
+                        EmailMessage(
+                            id=num.decode(),
+                            subject=msg.get("Subject", ""),
+                            sender=msg.get("From", ""),
+                        )
+                    )
+                return messages
+        except Exception:
+            return []
+
+
+class OutlookProvider(BaseEmailProvider):
+    """Fetch messages from an Outlook inbox via IMAP."""
+
+    SERVER = "imap-mail.outlook.com"
+
+    def __init__(self, username: Optional[str] = None, password: Optional[str] = None) -> None:
+        self.username = username or os.getenv("OUTLOOK_USERNAME")
+        self.password = password or os.getenv("OUTLOOK_PASSWORD")
+
+    def list_messages(self, max_results: int = 10) -> List[EmailMessage]:
+        if not self.username or not self.password:
+            return []
+        try:
+            with imaplib.IMAP4_SSL(self.SERVER) as imap:
+                imap.login(self.username, self.password)
+                imap.select("inbox")
+                _typ, data = imap.search(None, "ALL")
+                ids = data[0].split()[-max_results:]
+                messages: List[EmailMessage] = []
+                for num in ids:
+                    _typ, msg_data = imap.fetch(num, "(BODY.PEEK[HEADER.FIELDS (SUBJECT FROM)])")
+                    raw = msg_data[0][1]
+                    msg = email.message_from_bytes(raw)
+                    messages.append(
+                        EmailMessage(
+                            id=num.decode(),
+                            subject=msg.get("Subject", ""),
+                            sender=msg.get("From", ""),
+                        )
+                    )
+                return messages
+        except Exception:
+            return []
+
+
+def get_provider(
+    name: str, username: Optional[str] = None, password: Optional[str] = None
+) -> Optional[BaseEmailProvider]:
+    """Return an email provider by name.
+
+    Optional ``username`` and ``password`` parameters allow callers to supply
+    credentials dynamically instead of relying on environment variables.
+    """
+
+    name = name.lower()
+    if name == "gmail":
+        return GmailProvider(username=username, password=password)
+    if name == "outlook":
+        return OutlookProvider(username=username, password=password)
+    return None

--- a/tests/test_email_endpoints.py
+++ b/tests/test_email_endpoints.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import types
+
+from fastapi.testclient import TestClient
+
+# Provide minimal jinja2 and multipart stubs so ``web_app`` can be imported
+class _DummyLoader:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class _DummyEnv:
+    def __init__(self, *args, **kwargs):
+        self.globals = {}
+
+
+sys.modules.setdefault(
+    "jinja2",
+    types.SimpleNamespace(
+        Environment=_DummyEnv,
+        FileSystemLoader=_DummyLoader,
+        contextfunction=lambda f: f,
+    ),
+)
+
+multipart_stub = types.SimpleNamespace(__version__="0")
+sys.modules.setdefault("multipart", multipart_stub)
+sys.modules.setdefault("multipart.multipart", types.SimpleNamespace(parse_options_header=lambda *a, **k: None))
+
+# Allow importing backend modules as top-level modules
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "backend"))
+import web_app  # type: ignore
+
+client = TestClient(web_app.app)
+
+
+def _assert_messages(resp):
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "messages" in data
+    assert isinstance(data["messages"], list)
+
+
+def test_gmail_endpoint_returns_list():
+    _assert_messages(client.get("/emails/gmail"))
+
+
+def test_outlook_endpoint_returns_list():
+    _assert_messages(client.get("/emails/outlook"))
+
+
+def test_gmail_sync_endpoint_returns_list(monkeypatch):
+    from emails import GmailProvider, EmailMessage
+
+    def fake_list_messages(self, max_results: int = 10):  # pragma: no cover - simple stub
+        return [EmailMessage(id="1", subject="Test", sender="sender@example.com")]
+
+    monkeypatch.setattr(GmailProvider, "list_messages", fake_list_messages)
+
+    resp = client.post(
+        "/emails/gmail/sync", json={"username": "user@gmail.com", "password": "secret"}
+    )
+    _assert_messages(resp)


### PR DESCRIPTION
## Summary
- allow email providers to accept credentials dynamically
- add `/emails/gmail/sync` endpoint that stores user credentials and lists messages
- document new Gmail sync flow in project READMEs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1dece869c83268f53d7aebcac30c1