### PR TITLE
feat: add gmail sync form

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,19 @@ and remember the OAuth credentials for future sessions. To enable this flow:
 
 The application can sync and send email through Gmail or Outlook.
 
-- **Sync** – Users provide their address and app password at runtime via
-  `POST /emails/{provider}/sync`. Credentials are kept in memory for the
-  session and reused when calling `GET /emails/{provider}`.
-- **Send** – Submit a message to `POST /emails/{provider}/send` with `to`,
-  `subject`, and `body` fields. If credentials were previously synced they are
-  reused; otherwise include `username` and `password` in the payload.
+1. **Prepare a Gmail app password** – Enable two‑factor authentication on your
+   Google account and generate an app password from the security settings.
+2. **Open the Emails page** – Start the backend and frontend servers, sign in,
+   then navigate to the **Emails** tab in the top bar.
+3. **Sync Gmail** – Enter your Gmail address and app password in the Sync Gmail
+   form. The backend stores the credentials in memory for the session and
+   fetches recent messages via `POST /emails/gmail/sync`.
+4. **List messages** – After syncing, the page displays results from
+   `GET /emails/gmail` (or `GET /emails/outlook`).
+5. **Send email** – Use the **Send Email** form which posts to
+   `POST /emails/{provider}/send` with `to`, `subject`, and `body` fields. If
+   credentials were previously synced they are reused; otherwise include
+   `username` and `password` in the payload.
 
 When credentials are missing the listing endpoint returns an empty list so the
 rest of the application continues to function.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -699,9 +699,19 @@ function createEmailsView(){
   const wrap=document.createElement('div');
   wrap.className='emails-view';
   const controls=document.createElement('div');
-  const gmailBtn=document.createElement('button'); gmailBtn.textContent='Sync Gmail';
-  const outlookBtn=document.createElement('button'); outlookBtn.textContent='Sync Outlook';
-  controls.append(gmailBtn,outlookBtn);
+  const gmailForm=document.createElement('form');
+  gmailForm.className='sync-form gmail-sync';
+  gmailForm.innerHTML=`<input name="username" type="email" placeholder="Gmail address" required>
+    <input name="password" type="password" placeholder="App password" required>
+    <button type="submit">Sync Gmail</button>`;
+
+  const outlookForm=document.createElement('form');
+  outlookForm.className='sync-form outlook-sync';
+  outlookForm.innerHTML=`<input name="username" type="email" placeholder="Outlook address" required>
+    <input name="password" type="password" placeholder="App password" required>
+    <button type="submit">Sync Outlook</button>`;
+
+  controls.append(gmailForm,outlookForm);
   const list=document.createElement('div'); list.id='email-list';
   const form=document.createElement('form');
   form.innerHTML=`<h3>Send Email</h3>
@@ -729,9 +739,11 @@ function createEmailsView(){
     });
   }
 
-  gmailBtn.addEventListener('click',async ()=>{
-    const username=prompt('Gmail username');
-    const password=prompt('Gmail password');
+  gmailForm.addEventListener('submit',async e=>{
+    e.preventDefault();
+    const fd=new FormData(gmailForm);
+    const username=fd.get('username');
+    const password=fd.get('password');
     if(!username||!password) return;
     await authFetch(`${window.API_BASE_URL}/emails/gmail/sync`,{
       method:'POST',
@@ -741,9 +753,11 @@ function createEmailsView(){
     render('gmail');
   });
 
-  outlookBtn.addEventListener('click',async ()=>{
-    const username=prompt('Outlook username');
-    const password=prompt('Outlook password');
+  outlookForm.addEventListener('submit',async e=>{
+    e.preventDefault();
+    const fd=new FormData(outlookForm);
+    const username=fd.get('username');
+    const password=fd.get('password');
     if(!username||!password) return;
     await authFetch(`${window.API_BASE_URL}/emails/outlook/sync`,{
       method:'POST',

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -485,3 +485,13 @@ button:hover{
 /* Responsive */
 @media (max-width:1024px) {
 }
+
+/* Email sync forms */
+.emails-view .sync-form{
+  display:inline-block;
+  margin-right:1rem;
+}
+
+.emails-view .sync-form input{
+  margin-right:0.5rem;
+}


### PR DESCRIPTION
## Summary
- add inline forms to sync Gmail or Outlook accounts
- document step-by-step Gmail sync instructions
- style email sync forms for better layout

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1ef17a04c8326b39a1f81d2cd144d